### PR TITLE
Copy bubble, two shortcuts, dark mode and full localization

### DIFF
--- a/Sources/SpeechMD/Dictation/DictationSession.swift
+++ b/Sources/SpeechMD/Dictation/DictationSession.swift
@@ -46,11 +46,11 @@ final class DictationSession {
 
     enum TargetIssue: Equatable {
         case missingPermission
-        case noTextField
+        case noTarget
 
-        static func current() -> TargetIssue? {
+        static func current(target: NSRunningApplication?) -> TargetIssue? {
             if !TextInserter.isTrusted { return .missingPermission }
-            if !TextInserter.focusedElementAcceptsText() { return .noTextField }
+            if target == nil { return .noTarget }
             return nil
         }
     }
@@ -79,7 +79,7 @@ final class DictationSession {
         targetApp = frontmost?.bundleIdentifier == Bundle.main.bundleIdentifier ? nil : frontmost
         self.expand = expand
         self.formatAsMarkdown = formatAsMarkdown
-        targetIssue = TargetIssue.current()
+        targetIssue = TargetIssue.current(target: targetApp)
 
         state = .starting
         liveText = ""

--- a/Sources/SpeechMD/Dictation/DictationSession.swift
+++ b/Sources/SpeechMD/Dictation/DictationSession.swift
@@ -36,10 +36,6 @@ final class DictationSession {
     func clearHistory() {
         history.removeAll()
     }
-    /// Ditado iniciado por toque curto no atalho fica "travado" ouvindo até o
-    /// próximo toque; iniciado segurando, termina quando a tecla é solta.
-    var isLatched = false
-
     var isRunning: Bool {
         state == .listening || state == .starting
     }
@@ -104,7 +100,6 @@ final class DictationSession {
     func finish() {
         startTask?.cancel()
         startTask = nil
-        isLatched = false
 
         let currentPipeline = pipeline
         let target = targetApp

--- a/Sources/SpeechMD/Dictation/DictationSession.swift
+++ b/Sources/SpeechMD/Dictation/DictationSession.swift
@@ -8,6 +8,12 @@ struct Dictation: Identifiable, Equatable {
     let createdAt: Date
 }
 
+struct DictationOutcome: Identifiable, Equatable {
+    let id = UUID()
+    let text: String
+    let needsCopy: Bool
+}
+
 /// Ditado estilo Wispr Flow: fala em qualquer app, o texto é colado lá.
 @MainActor
 @Observable
@@ -54,7 +60,7 @@ final class DictationSession {
 
     var hasEditableTarget: Bool { targetIssue == nil }
 
-    private(set) var undelivered: Dictation?
+    private(set) var outcome: DictationOutcome?
 
     private var pipeline: SpeechPipeline?
     private var startTask: Task<Void, Never>?
@@ -113,19 +119,22 @@ final class DictationSession {
 
             let raw = liveText.trimmingCharacters(in: .whitespacesAndNewlines)
             liveText = ""
-            guard !raw.isEmpty else { return }
+            guard !raw.isEmpty else {
+                outcome = DictationOutcome(text: "", needsCopy: false)
+                return
+            }
 
             var text = expand(raw)
             if formatAsMarkdown {
                 text = await TranscriptFormatter.format(text)
             }
-            let dictation = Dictation(text: text, createdAt: Date())
-            history.insert(dictation, at: 0)
+            history.insert(Dictation(text: text, createdAt: Date()), at: 0)
             guard hasEditableTarget else {
-                undelivered = dictation
+                outcome = DictationOutcome(text: text, needsCopy: true)
                 return
             }
             await TextInserter.insert(text, into: target)
+            outcome = DictationOutcome(text: text, needsCopy: false)
         }
     }
 }

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -32,6 +32,7 @@ struct DictationView: View {
                             Spacer()
                             Button("Limpar tudo") { session.clearHistory() }
                                 .controlSize(.small)
+                                .pointerStyle(.link)
                         }
 
                         VStack(spacing: 0) {

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -103,7 +103,7 @@ struct DictationView: View {
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 18)
-        .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
+        .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
     }
 
     private var headerTitle: String {
@@ -156,7 +156,7 @@ struct DictationView: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 7)
-                    .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
             .buttonStyle(.plain)
             .pointerStyle(.link)

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DictationView: View {
     let session: DictationSession
     let hotkey: HotkeyBinding
+    let pushToTalkHotkey: HotkeyBinding
     let onToggle: () -> Void
 
     @State private var needsPermission = !TextInserter.isTrusted
@@ -76,7 +77,7 @@ struct DictationView: View {
             }
             Spacer(minLength: 12)
 
-            Text(hotkey.displayString)
+            Text(pushToTalkHotkey.displayString)
                 .font(.system(size: 12, weight: .medium, design: .rounded))
                 .foregroundStyle(.white.opacity(0.75))
                 .padding(.horizontal, 11)
@@ -136,8 +137,8 @@ struct DictationView: View {
 
     private var instructions: String {
         t(
-            "Segure \(hotkey.displayString) e fale, ao soltar o texto é colado no app em foco. Dois toques gravam até o toque seguinte.",
-            "Hold \(hotkey.displayString) and speak, on release the text is pasted into the focused app. A double tap records until the next tap."
+            "Segure \(pushToTalkHotkey.displayString) e fale, ao soltar o texto é colado no app em foco. \(hotkey.displayString) começa e encerra a gravação num toque.",
+            "Hold \(pushToTalkHotkey.displayString) and speak, on release the text is pasted into the focused app. \(hotkey.displayString) starts and stops the recording on a tap."
         )
     }
 
@@ -184,7 +185,7 @@ struct DictationView: View {
             Text(t("Nada transcrito ainda", "Nothing transcribed yet"))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Theme.textPrimary)
-            Text(t("Clique em Falar ou use \(hotkey.displayString) de qualquer app.", "Click Speak or press \(hotkey.displayString) from any app."))
+            Text(t("Clique em Falar ou use \(pushToTalkHotkey.displayString) de qualquer app.", "Click Speak or press \(pushToTalkHotkey.displayString) from any app."))
                 .font(.system(size: 13))
                 .foregroundStyle(Theme.textSecondary)
         }

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DictationView: View {
     let session: DictationSession
     let hotkey: HotkeyBinding
+    let hotkeyMode: HotkeyMode
     let onToggle: () -> Void
 
     @State private var needsPermission = !TextInserter.isTrusted
@@ -69,7 +70,7 @@ struct DictationView: View {
                 Text(headerTitle)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text(t("Segure o atalho e fale, ao soltar o texto é colado no app em foco. Um toque curto mantém ouvindo até o toque seguinte.", "Hold the shortcut and speak, on release the text is pasted into the focused app. A short tap keeps it listening until the next tap."))
+                Text(instructions)
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)
@@ -93,7 +94,7 @@ struct DictationView: View {
                     Text(session.isRunning ? t("Parar", "Stop") : t("Falar", "Speak"))
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .foregroundStyle(Theme.textPrimary)
+                .foregroundStyle(Theme.contrastSurface)
                 .padding(.horizontal, 16)
                 .frame(height: 34)
                 .background(.white, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
@@ -108,7 +109,7 @@ struct DictationView: View {
 
     private var headerTitle: String {
         guard session.isRunning else { return t("Escrever falando", "Write by speaking") }
-        return session.isLatched ? t("Ouvindo (travado)", "Listening (latched)") : t("Ouvindo…", "Listening…")
+        return t("Ouvindo…", "Listening…")
     }
 
     private var liveCard: some View {
@@ -131,6 +132,21 @@ struct DictationView: View {
         .overlay {
             RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous)
                 .stroke(Theme.live.opacity(0.4), lineWidth: 1)
+        }
+    }
+
+    private var instructions: String {
+        switch hotkeyMode {
+        case .hold:
+            t(
+                "Segure \(hotkey.displayString) e fale, ao soltar o texto é colado no app em foco.",
+                "Hold \(hotkey.displayString) and speak, on release the text is pasted into the focused app."
+            )
+        case .toggle:
+            t(
+                "Toque \(hotkey.displayString) e fale, o toque seguinte encerra e cola o texto no app em foco.",
+                "Tap \(hotkey.displayString) and speak, the next tap stops and pastes into the focused app."
+            )
         }
     }
 

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -25,12 +25,12 @@ struct DictationView: View {
                 } else {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack {
-                            Text("HISTÓRICO")
+                            Text(t("HISTÓRICO", "HISTORY"))
                                 .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(Theme.textTertiary)
                                 .tracking(0.6)
                             Spacer()
-                            Button("Limpar tudo") { session.clearHistory() }
+                            Button(t("Limpar tudo", "Clear all")) { session.clearHistory() }
                                 .controlSize(.small)
                                 .pointerStyle(.link)
                         }
@@ -69,7 +69,7 @@ struct DictationView: View {
                 Text(headerTitle)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("Segure o atalho e fale, ao soltar o texto é colado no app em foco. Um toque curto mantém ouvindo até o toque seguinte.")
+                Text(t("Segure o atalho e fale, ao soltar o texto é colado no app em foco. Um toque curto mantém ouvindo até o toque seguinte.", "Hold the shortcut and speak, on release the text is pasted into the focused app. A short tap keeps it listening until the next tap."))
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)
@@ -79,8 +79,8 @@ struct DictationView: View {
             Text(hotkey.displayString)
                 .font(.system(size: 12, weight: .medium, design: .rounded))
                 .foregroundStyle(.white.opacity(0.75))
-                .padding(.horizontal, 9)
-                .padding(.vertical, 5)
+                .padding(.horizontal, 11)
+                .frame(height: 34)
                 .overlay {
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
                         .stroke(.white.opacity(0.25), lineWidth: 1)
@@ -90,12 +90,12 @@ struct DictationView: View {
                 HStack(spacing: 7) {
                     Image(systemName: session.isRunning ? "stop.fill" : "mic.fill")
                         .font(.system(size: 12, weight: .semibold))
-                    Text(session.isRunning ? "Parar" : "Falar")
+                    Text(session.isRunning ? t("Parar", "Stop") : t("Falar", "Speak"))
                         .font(.system(size: 13, weight: .semibold))
                 }
                 .foregroundStyle(Theme.textPrimary)
                 .padding(.horizontal, 16)
-                .padding(.vertical, 9)
+                .frame(height: 34)
                 .background(.white, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
             }
             .buttonStyle(.plain)
@@ -107,20 +107,20 @@ struct DictationView: View {
     }
 
     private var headerTitle: String {
-        guard session.isRunning else { return "Escrever falando" }
-        return session.isLatched ? "Ouvindo (travado)" : "Ouvindo…"
+        guard session.isRunning else { return t("Escrever falando", "Write by speaking") }
+        return session.isLatched ? t("Ouvindo (travado)", "Listening (latched)") : t("Ouvindo…", "Listening…")
     }
 
     private var liveCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 7) {
                 Circle().fill(Theme.live).frame(width: 6, height: 6)
-                Text("Transcrevendo")
+                Text(t("Transcrevendo", "Transcribing"))
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(Theme.live)
                     .tracking(0.4)
             }
-            Text(session.liveText.isEmpty ? "Fale algo…" : session.liveText)
+            Text(session.liveText.isEmpty ? t("Fale algo…", "Say something…") : session.liveText)
                 .font(.system(size: 14))
                 .foregroundStyle(session.liveText.isEmpty ? Theme.textTertiary : Theme.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -140,10 +140,10 @@ struct DictationView: View {
                 .font(.system(size: 18))
                 .foregroundStyle(Theme.highlight)
             VStack(alignment: .leading, spacing: 3) {
-                Text("Falta permissão de Acessibilidade")
+                Text(t("Falta permissão de Acessibilidade", "Accessibility permission missing"))
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Theme.textPrimary)
-                Text("Sem ela o texto é transcrito mas não consegue ser colado no app em foco.")
+                Text(t("Sem ela o texto é transcrito mas não consegue ser colado no app em foco.", "Without it the text is transcribed but cannot be pasted into the focused app."))
                     .font(.system(size: 12))
                     .foregroundStyle(Theme.textSecondary)
             }
@@ -151,7 +151,7 @@ struct DictationView: View {
             Button {
                 SystemPermission.accessibility.requestIfPossible()
             } label: {
-                Text("Permitir")
+                Text(t("Permitir", "Allow"))
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 14)
@@ -174,10 +174,10 @@ struct DictationView: View {
             Image(systemName: "text.cursor")
                 .font(.system(size: 26, weight: .light))
                 .foregroundStyle(Theme.textTertiary)
-            Text("Nada transcrito ainda")
+            Text(t("Nada transcrito ainda", "Nothing transcribed yet"))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Theme.textPrimary)
-            Text("Clique em Falar ou use \(hotkey.displayString) de qualquer app.")
+            Text(t("Clique em Falar ou use \(hotkey.displayString) de qualquer app.", "Click Speak or press \(hotkey.displayString) from any app."))
                 .font(.system(size: 13))
                 .foregroundStyle(Theme.textSecondary)
         }

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -69,7 +69,7 @@ struct DictationView: View {
                 Text(headerTitle)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("Segure o atalho e fale — ao soltar, o texto é colado no app em foco. Um toque curto mantém ouvindo até o toque seguinte.")
+                Text("Segure o atalho e fale, ao soltar o texto é colado no app em foco. Um toque curto mantém ouvindo até o toque seguinte.")
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/SpeechMD/Dictation/DictationView.swift
+++ b/Sources/SpeechMD/Dictation/DictationView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct DictationView: View {
     let session: DictationSession
     let hotkey: HotkeyBinding
-    let hotkeyMode: HotkeyMode
     let onToggle: () -> Void
 
     @State private var needsPermission = !TextInserter.isTrusted
@@ -136,18 +135,10 @@ struct DictationView: View {
     }
 
     private var instructions: String {
-        switch hotkeyMode {
-        case .hold:
-            t(
-                "Segure \(hotkey.displayString) e fale, ao soltar o texto é colado no app em foco.",
-                "Hold \(hotkey.displayString) and speak, on release the text is pasted into the focused app."
-            )
-        case .toggle:
-            t(
-                "Toque \(hotkey.displayString) e fale, o toque seguinte encerra e cola o texto no app em foco.",
-                "Tap \(hotkey.displayString) and speak, the next tap stops and pastes into the focused app."
-            )
-        }
+        t(
+            "Segure \(hotkey.displayString) e fale, ao soltar o texto é colado no app em foco. Dois toques gravam até o toque seguinte.",
+            "Hold \(hotkey.displayString) and speak, on release the text is pasted into the focused app. A double tap records until the next tap."
+        )
     }
 
     private var permissionCard: some View {

--- a/Sources/SpeechMD/Dictation/TextInserter.swift
+++ b/Sources/SpeechMD/Dictation/TextInserter.swift
@@ -12,37 +12,6 @@ enum TextInserter {
         AXIsProcessTrusted()
     }
 
-    /// Existe algo editável em foco pra receber o texto?
-    ///
-    /// Sem isto o ditado seria transcrito e o ⌘V cairia no vazio — nenhum erro,
-    /// só o texto sumindo.
-    static func focusedElementAcceptsText() -> Bool {
-        guard isTrusted else { return false }
-
-        let systemWide = AXUIElementCreateSystemWide()
-        var focused: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedUIElementAttribute as CFString,
-            &focused
-        ) == .success, let focused else {
-            return false
-        }
-
-        let element = focused as! AXUIElement
-
-        var roleValue: CFTypeRef?
-        AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleValue)
-        if let role = roleValue as? String,
-           [kAXTextFieldRole, kAXTextAreaRole, kAXComboBoxRole].contains(role) {
-            return true
-        }
-        var isSettable: DarwinBoolean = false
-        AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &isSettable)
-        return isSettable.boolValue
-    }
-
-
     /// `target` é o app que estava na frente quando o ditado começou. Sem
     /// devolver o foco a ele, o ⌘V cairia na janela do speech.md — que é o que
     /// acontece sempre que o ditado é iniciado pelo botão da interface.

--- a/Sources/SpeechMD/Files/FileTranscriptionView.swift
+++ b/Sources/SpeechMD/Files/FileTranscriptionView.swift
@@ -38,7 +38,7 @@ struct FileTranscriptionView: View {
                 .multilineTextAlignment(.center)
 
             if !model.isBusy {
-                Button("Escolher arquivo…", action: onChooseFile)
+                Button(t("Escolher arquivo…", "Choose file…"), action: onChooseFile)
                     .controlSize(.large)
                     .pointerStyle(.link)
                     .padding(.top, 6)
@@ -67,7 +67,7 @@ struct FileTranscriptionView: View {
     private var transcriptCard: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text("TRANSCRIÇÃO")
+                Text(t("TRANSCRIÇÃO", "TRANSCRIPT"))
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(Theme.textTertiary)
                     .tracking(0.6)
@@ -77,10 +77,10 @@ struct FileTranscriptionView: View {
                         .font(.system(size: 11).monospacedDigit())
                         .foregroundStyle(Theme.textTertiary)
                 }
-                Button("Copiar") { model.copyTranscript() }
+                Button(t("Copiar", "Copy")) { model.copyTranscript() }
                     .controlSize(.small)
                     .pointerStyle(.link)
-                Button("Salvar…") { model.saveTranscript(suggestedName: fileName) }
+                Button(t("Salvar…", "Save…")) { model.saveTranscript(suggestedName: fileName) }
                     .controlSize(.small)
                     .pointerStyle(.link)
             }
@@ -110,18 +110,18 @@ struct FileTranscriptionView: View {
 
     private var statusTitle: String {
         switch model.state {
-        case .idle: "Transcrever um arquivo"
-        case .transcribing(let name): "Transcrevendo \(name)"
+        case .idle: t("Transcrever um arquivo", "Transcribe a file")
+        case .transcribing(let name): t("Transcrevendo \(name)", "Transcribing \(name)")
         case .done(let name): name
-        case .failed: "Não deu para transcrever"
+        case .failed: t("Não deu para transcrever", "Could not transcribe")
         }
     }
 
     private var statusSubtitle: String {
         switch model.state {
-        case .idle: "Arraste um áudio aqui ou escolha do disco. Tudo roda no seu Mac."
-        case .transcribing: "Processando no dispositivo…"
-        case .done: "Pronto. Arraste outro arquivo para transcrever de novo."
+        case .idle: t("Arraste um áudio aqui ou escolha do disco. Tudo roda no seu Mac.", "Drop an audio file here or pick one from disk. Everything runs on your Mac.")
+        case .transcribing: t("Processando no dispositivo…", "Processing on device…")
+        case .done: t("Pronto. Arraste outro arquivo para transcrever de novo.", "Done. Drop another file to transcribe again.")
         case .failed(let message): message
         }
     }

--- a/Sources/SpeechMD/Files/FileTranscriptionView.swift
+++ b/Sources/SpeechMD/Files/FileTranscriptionView.swift
@@ -40,6 +40,7 @@ struct FileTranscriptionView: View {
             if !model.isBusy {
                 Button("Escolher arquivo…", action: onChooseFile)
                     .controlSize(.large)
+                    .pointerStyle(.link)
                     .padding(.top, 6)
             }
         }
@@ -78,8 +79,10 @@ struct FileTranscriptionView: View {
                 }
                 Button("Copiar") { model.copyTranscript() }
                     .controlSize(.small)
+                    .pointerStyle(.link)
                 Button("Salvar…") { model.saveTranscript(suggestedName: fileName) }
                     .controlSize(.small)
+                    .pointerStyle(.link)
             }
 
             Text(model.transcript)

--- a/Sources/SpeechMD/Formatting/TranscriptFormatter.swift
+++ b/Sources/SpeechMD/Formatting/TranscriptFormatter.swift
@@ -12,9 +12,9 @@ enum TranscriptFormatter {
     - Corrija apenas pontuação, capitalização e quebras de linha.
 
     FORMATAÇÃO:
-    - Se o texto enumerar itens, transforme-os em lista com "- ".
-    - Mantenha como parágrafo comum o texto que não é enumeração.
-    - Use **negrito** apenas onde o autor pedir ênfase explicitamente.
+    - Uma frase solta é um parágrafo. Nunca vire lista.
+    - Só use lista, com "- ", quando houver dois ou mais itens enumerados.
+    - Nunca use negrito, itálico, título ou numeração.
 
     Responda apenas com o texto formatado, sem comentários.
     """
@@ -30,11 +30,23 @@ enum TranscriptFormatter {
         do {
             let session = LanguageModelSession(instructions: instructions)
             let response = try await session.respond(to: raw)
-            let formatted = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            let formatted = sanitize(response.content.trimmingCharacters(in: .whitespacesAndNewlines))
             return preservesContent(raw: raw, formatted: formatted) ? formatted : raw
         } catch {
             return raw
         }
+    }
+
+    private static func sanitize(_ formatted: String) -> String {
+        let marker = /^[ \t]*(?:[-*+]|\d+[.)])[ \t]+/
+        var lines = formatted.components(separatedBy: .newlines)
+        if lines.count(where: { $0.contains(marker) }) < 2 {
+            lines = lines.map { $0.replacing(marker, with: "") }
+        }
+        return lines
+            .joined(separator: "\n")
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "__", with: "")
     }
 
     /// O modelo às vezes engole frases inteiras ao reformatar. Se muita palavra

--- a/Sources/SpeechMD/Island/DynamicIslandView.swift
+++ b/Sources/SpeechMD/Island/DynamicIslandView.swift
@@ -10,6 +10,7 @@ struct DynamicIslandView: View {
     /// Segundos até o aviso sumir — a barra drena nesse tempo.
     var countdownDuration: TimeInterval = 3
     var result: String?
+    var isProcessing = false
     var isClosing = false
     var onCopy: (() -> Void)?
 
@@ -80,7 +81,14 @@ struct DynamicIslandView: View {
     /// o mesmo ponto da tela conta quanto falta pra ilha fechar.
     @ViewBuilder
     private var leftEar: some View {
-        if warning != nil {
+        if isProcessing {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.small)
+                .tint(.white)
+                .scaleEffect(0.62)
+                .frame(width: 15, height: 15)
+        } else if warning != nil {
             CountdownRing(progress: drain)
                 .frame(width: 15, height: 15)
                 .onAppear {

--- a/Sources/SpeechMD/Island/DynamicIslandView.swift
+++ b/Sources/SpeechMD/Island/DynamicIslandView.swift
@@ -128,7 +128,7 @@ struct DynamicIslandView: View {
                                 withAnimation(.linear(duration: countdownDuration)) { drain = 0 }
                             }
                     }
-                    Text(didCopy ? "Copiado" : "Copiar")
+                    Text(didCopy ? t("Copiado", "Copied") : t("Copiar", "Copy"))
                         .font(.system(size: 11, weight: .semibold, design: .rounded))
                 }
                 .foregroundStyle(.black)

--- a/Sources/SpeechMD/Island/DynamicIslandView.swift
+++ b/Sources/SpeechMD/Island/DynamicIslandView.swift
@@ -82,12 +82,8 @@ struct DynamicIslandView: View {
     @ViewBuilder
     private var leftEar: some View {
         if isProcessing {
-            ProgressView()
-                .progressViewStyle(.circular)
-                .controlSize(.small)
-                .tint(.white)
-                .scaleEffect(0.62)
-                .frame(width: 15, height: 15)
+            CountdownRing(progress: 0.3, tint: .white, spinning: true)
+                .frame(width: 14, height: 14)
         } else if warning != nil {
             CountdownRing(progress: drain)
                 .frame(width: 15, height: 15)
@@ -214,6 +210,9 @@ private struct CountdownRing: View {
     var progress: CGFloat
     var tint: Color = .yellow
     var track: Color = .white.opacity(0.18)
+    var spinning = false
+
+    @State private var turn = false
 
     var body: some View {
         ZStack {
@@ -223,6 +222,15 @@ private struct CountdownRing: View {
                 .trim(from: 0, to: max(0, min(1, progress)))
                 .stroke(tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90)) // começa no topo
+                .rotationEffect(.degrees(turn ? 360 : 0))
+                .animation(
+                    spinning ? .linear(duration: 0.75).repeatForever(autoreverses: false) : nil,
+                    value: turn
+                )
+        }
+        .onAppear {
+            guard spinning else { return }
+            turn = true
         }
     }
 }

--- a/Sources/SpeechMD/Island/IslandController.swift
+++ b/Sources/SpeechMD/Island/IslandController.swift
@@ -28,6 +28,13 @@ final class IslandController {
         }
     }
 
+    var isProcessing = false {
+        didSet {
+            guard isProcessing != oldValue else { return }
+            render()
+        }
+    }
+
     private var isClosing = false {
         didSet {
             guard isClosing != oldValue else { return }
@@ -148,6 +155,7 @@ final class IslandController {
                 (result == nil ? Self.warningDuration : Self.resultDuration).components.seconds
             ),
             result: result,
+            isProcessing: isProcessing,
             isClosing: isClosing,
             onCopy: { [weak self] in
                 guard let self, let text = result else { return }

--- a/Sources/SpeechMD/Island/IslandController.swift
+++ b/Sources/SpeechMD/Island/IslandController.swift
@@ -107,7 +107,12 @@ final class IslandController {
     }
 
     /// Ligado por quem controla a sessão; enquanto true a ilha permanece.
-    var isSessionActive = false
+    var isSessionActive = false {
+        didSet {
+            guard isSessionActive != oldValue else { return }
+            if !isSessionActive { stopTicker() }
+        }
+    }
 
     private func startTicker() {
         elapsed = 0

--- a/Sources/SpeechMD/Localization/Language.swift
+++ b/Sources/SpeechMD/Localization/Language.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum Language {
+    nonisolated(unsafe) static var isEnglish = false
+
+    static func matches(localeIdentifier: String) -> Bool {
+        localeIdentifier.hasPrefix("en")
+    }
+}
+
+func t(_ portuguese: String, _ english: String) -> String {
+    Language.isEnglish ? english : portuguese
+}

--- a/Sources/SpeechMD/Meetings/LiveMeetingView.swift
+++ b/Sources/SpeechMD/Meetings/LiveMeetingView.swift
@@ -15,14 +15,14 @@ struct LiveMeetingView: View {
             } else {
                 HStack(alignment: .top, spacing: 14) {
                     channel(
-                        title: "Você",
+                        title: t("Você", "You"),
                         systemImage: "person.fill",
                         accent: Theme.accent,
                         text: model.youTranscript,
                         metrics: model.youMetrics
                     )
                     channel(
-                        title: "Outros",
+                        title: t("Outros", "Others"),
                         systemImage: "person.2.fill",
                         accent: Theme.live,
                         text: model.othersTranscript,
@@ -37,7 +37,7 @@ struct LiveMeetingView: View {
         HStack(spacing: 12) {
             HStack(spacing: 7) {
                 Circle().fill(Theme.live).frame(width: 7, height: 7)
-                Text(model.phase == .preparing ? "Preparando modelo…" : "Gravando")
+                Text(model.phase == .preparing ? t("Preparando modelo…", "Preparing model…") : t("Gravando", "Recording"))
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.white)
             }
@@ -53,7 +53,7 @@ struct LiveMeetingView: View {
                 HStack(spacing: 7) {
                     Image(systemName: "stop.fill")
                         .font(.system(size: 11, weight: .semibold))
-                    Text("Encerrar")
+                    Text(t("Encerrar", "Finish"))
                         .font(.system(size: 13, weight: .semibold))
                 }
                 .foregroundStyle(Theme.textPrimary)
@@ -95,7 +95,7 @@ struct LiveMeetingView: View {
             }
 
             ScrollView {
-                Text(text.isEmpty ? "Aguardando áudio…" : text)
+                Text(text.isEmpty ? t("Aguardando áudio…", "Waiting for audio…") : text)
                     .font(.system(size: 13))
                     .foregroundStyle(text.isEmpty ? Theme.textTertiary : Theme.textPrimary)
                     .textSelection(.enabled)

--- a/Sources/SpeechMD/Meetings/LiveMeetingView.swift
+++ b/Sources/SpeechMD/Meetings/LiveMeetingView.swift
@@ -56,7 +56,7 @@ struct LiveMeetingView: View {
                     Text(t("Encerrar", "Finish"))
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .foregroundStyle(Theme.textPrimary)
+                .foregroundStyle(Theme.contrastSurface)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 9)
                 .background(.white, in: RoundedRectangle(cornerRadius: 9, style: .continuous))

--- a/Sources/SpeechMD/Meetings/LiveMeetingView.swift
+++ b/Sources/SpeechMD/Meetings/LiveMeetingView.swift
@@ -66,7 +66,7 @@ struct LiveMeetingView: View {
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 16)
-        .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
+        .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
     }
 
     private func channel(

--- a/Sources/SpeechMD/Meetings/MeetingFeedView.swift
+++ b/Sources/SpeechMD/Meetings/MeetingFeedView.swift
@@ -65,7 +65,7 @@ struct MeetingFeedView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(Theme.live)
             VStack(alignment: .leading, spacing: 6) {
-                Text("A gravação não começou")
+                Text(t("A gravação não começou", "Recording did not start"))
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Theme.textPrimary)
                 Text(message)
@@ -78,7 +78,7 @@ struct MeetingFeedView: View {
                         Button {
                             SystemPermission.screenRecording.requestIfPossible()
                         } label: {
-                            Text("Permitir")
+                            Text(t("Permitir", "Allow"))
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(.white)
                                 .padding(.horizontal, 12)
@@ -88,7 +88,7 @@ struct MeetingFeedView: View {
                         .buttonStyle(.plain)
                         .pointerStyle(.link)
 
-                        Button("Gravar só meu microfone", action: onUseMicrophoneOnly)
+                        Button(t("Gravar só meu microfone", "Record my microphone only"), action: onUseMicrophoneOnly)
                             .font(.system(size: 12))
                             .controlSize(.small)
                             .pointerStyle(.link)
@@ -111,10 +111,10 @@ struct MeetingFeedView: View {
             Image(systemName: "waveform")
                 .font(.system(size: 26, weight: .light))
                 .foregroundStyle(Theme.textTertiary)
-            Text("Nenhuma reunião gravada")
+            Text(t("Nenhuma reunião gravada", "No meetings recorded"))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Theme.textPrimary)
-            Text("Clique em Começar para gravar sua primeira reunião.")
+            Text(t("Clique em Começar para gravar sua primeira reunião.", "Click Start to record your first meeting."))
                 .font(.system(size: 13))
                 .foregroundStyle(Theme.textSecondary)
         }
@@ -125,10 +125,10 @@ struct MeetingFeedView: View {
     private var startBar: some View {
         HStack(spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(isRecording ? "Gravando reunião" : "Gravar reunião")
+                Text(isRecording ? t("Gravando reunião", "Recording meeting") : t("Gravar reunião", "Record meeting"))
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("Sua voz e a dos outros participantes, separadas e no seu Mac.")
+                Text(t("Sua voz e a dos outros participantes, separadas e no seu Mac.", "Your voice and the other participants, on separate channels, on your Mac."))
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
             }
@@ -138,7 +138,7 @@ struct MeetingFeedView: View {
                 HStack(spacing: 7) {
                     Image(systemName: isRecording ? "stop.fill" : "record.circle")
                         .font(.system(size: 12, weight: .semibold))
-                    Text(isRecording ? "Parar" : "Começar")
+                    Text(isRecording ? t("Parar", "Stop") : t("Começar", "Start"))
                         .font(.system(size: 13, weight: .semibold))
                 }
                 .foregroundStyle(Theme.textPrimary)
@@ -215,7 +215,7 @@ private struct LiveBadge: View {
             Circle()
                 .fill(Theme.live)
                 .frame(width: 5, height: 5)
-            Text("AO VIVO")
+            Text(t("AO VIVO", "LIVE"))
                 .font(.system(size: 9, weight: .bold))
                 .tracking(0.4)
         }

--- a/Sources/SpeechMD/Meetings/MeetingFeedView.swift
+++ b/Sources/SpeechMD/Meetings/MeetingFeedView.swift
@@ -91,6 +91,7 @@ struct MeetingFeedView: View {
                         Button("Gravar só meu microfone", action: onUseMicrophoneOnly)
                             .font(.system(size: 12))
                             .controlSize(.small)
+                            .pointerStyle(.link)
                     }
                     .padding(.top, 4)
                 }

--- a/Sources/SpeechMD/Meetings/MeetingFeedView.swift
+++ b/Sources/SpeechMD/Meetings/MeetingFeedView.swift
@@ -83,7 +83,7 @@ struct MeetingFeedView: View {
                                 .foregroundStyle(.white)
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
-                                .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                                .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                         }
                         .buttonStyle(.plain)
                         .pointerStyle(.link)
@@ -151,7 +151,7 @@ struct MeetingFeedView: View {
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 18)
-        .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
+        .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
     }
 }
 

--- a/Sources/SpeechMD/Meetings/MeetingFeedView.swift
+++ b/Sources/SpeechMD/Meetings/MeetingFeedView.swift
@@ -141,7 +141,7 @@ struct MeetingFeedView: View {
                     Text(isRecording ? t("Parar", "Stop") : t("Começar", "Start"))
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .foregroundStyle(Theme.textPrimary)
+                .foregroundStyle(Theme.contrastSurface)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 9)
                 .background(.white, in: RoundedRectangle(cornerRadius: 9, style: .continuous))

--- a/Sources/SpeechMD/Notetaker/NotetakerModels.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerModels.swift
@@ -9,6 +9,16 @@ enum NavSection: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    var title: String {
+        switch self {
+        case .dictation: t("Falar", "Speak")
+        case .notetaker: t("Reuniões", "Meetings")
+        case .files: t("Arquivos", "Files")
+        case .dictionary: t("Dicionário", "Dictionary")
+        case .settings: t("Configurações", "Settings")
+        }
+    }
+
     /// Configurações mora no rodapé da sidebar, junto dos links.
     static var primary: [NavSection] {
         allCases.filter { $0 != .settings }
@@ -85,15 +95,15 @@ struct MeetingDay: Identifiable {
     }
 
     private static func label(for day: Date, calendar: Calendar) -> String {
-        if calendar.isDateInToday(day) { return "Hoje" }
-        if calendar.isDateInYesterday(day) { return "Ontem" }
+        if calendar.isDateInToday(day) { return t("Hoje", "Today") }
+        if calendar.isDateInYesterday(day) { return t("Ontem", "Yesterday") }
         return dayFormatter.string(from: day)
     }
 
     private static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "pt_BR")
-        formatter.dateFormat = "d 'de' MMMM"
+        formatter.dateFormat = t("d 'de' MMMM", "MMMM d")
         return formatter
     }()
 }

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -15,6 +15,12 @@ struct NotetakerShell: View {
     @State private var meetings: [Meeting] = []
     @State private var meetingStartedAt: Date?
     @State private var elapsed: TimeInterval = 0
+    @State private var pressedAt: Date?
+    @State private var isLatched = false
+    @State private var secondTapWindow: Task<Void, Never>?
+
+    /// Acima disso o atalho conta como "segurar", não como toque.
+    private static let tapThreshold: TimeInterval = 0.35
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $selection, isCollapsed: $isSidebarCollapsed)
@@ -77,7 +83,6 @@ struct NotetakerShell: View {
             DictationView(
                 session: dictation,
                 hotkey: settings.hotkey,
-                hotkeyMode: settings.hotkeyMode,
                 onToggle: toggleDictation
             )
         case .notetaker:
@@ -129,16 +134,44 @@ struct NotetakerShell: View {
     private func hotkeyPressed() {
         guard !model.phase.isRunning else { return }
 
-        if dictation.isRunning {
+        if isLatched {
+            isLatched = false
+            secondTapWindow?.cancel()
+            secondTapWindow = nil
             finishDictation()
             return
         }
+
+        if dictation.isRunning, secondTapWindow != nil {
+            secondTapWindow?.cancel()
+            secondTapWindow = nil
+            isLatched = true
+            return
+        }
+
+        pressedAt = Date()
         startDictation()
     }
 
+    /// Soltar rápido não encerra na hora: é preciso dar tempo do segundo toque
+    /// chegar, senão o duplo toque nunca aconteceria.
     private func hotkeyReleased() {
-        guard settings.hotkeyMode == .hold, dictation.isRunning else { return }
-        finishDictation()
+        guard dictation.isRunning, let pressedAt else { return }
+        let held = Date().timeIntervalSince(pressedAt)
+        self.pressedAt = nil
+
+        guard held < Self.tapThreshold else {
+            finishDictation()
+            return
+        }
+
+        secondTapWindow = Task {
+            try? await Task.sleep(for: .milliseconds(340))
+            guard !Task.isCancelled else { return }
+            secondTapWindow = nil
+            guard !isLatched else { return }
+            finishDictation()
+        }
     }
 
     private func toggleDictation() {
@@ -159,6 +192,7 @@ struct NotetakerShell: View {
     }
 
     private func finishDictation() {
+        isLatched = false
         dictation.finish()
         island.isSessionActive = false
         island.warning = nil

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -20,8 +20,6 @@ struct NotetakerShell: View {
     /// Abaixo disso o atalho conta como toque, não como "segurar".
     private static let tapThreshold: TimeInterval = 0.4
 
-    private let ticker = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $selection, isCollapsed: $isSidebarCollapsed)
@@ -38,6 +36,7 @@ struct NotetakerShell: View {
             }
             .background(Theme.canvas)
         }
+        .id(settings.localeIdentifier)
         .frame(minWidth: 1_060, minHeight: 700)
         .background(Theme.canvas)
         // paleta do Theme é clara e fixa; sem isto sheets, campos e pickers
@@ -70,9 +69,12 @@ struct NotetakerShell: View {
             island.isVisible = false
             meetingStartedAt = nil
         }
-        .onReceive(ticker) { _ in
-            guard let meetingStartedAt else { return }
-            elapsed = Date().timeIntervalSince(meetingStartedAt)
+        .task(id: meetingStartedAt) {
+            guard let startedAt = meetingStartedAt else { return }
+            while !Task.isCancelled {
+                elapsed = Date().timeIntervalSince(startedAt)
+                try? await Task.sleep(for: .seconds(1))
+            }
         }
     }
 
@@ -221,7 +223,10 @@ struct NotetakerShell: View {
         let excerpt = [you, others].first { !$0.isEmpty } ?? ""
         meetings.insert(
             Meeting(
-                title: "Reunião de \(Meeting.titleFormatter.string(from: startedAt))",
+                title: t(
+                    "Reunião de \(Meeting.titleFormatter.string(from: startedAt))",
+                    "Meeting at \(Meeting.titleFormatter.string(from: startedAt))"
+                ),
                 startedAt: startedAt,
                 duration: duration,
                 participants: others.isEmpty ? 1 : 2,

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -15,11 +15,6 @@ struct NotetakerShell: View {
     @State private var meetings: [Meeting] = []
     @State private var meetingStartedAt: Date?
     @State private var elapsed: TimeInterval = 0
-    @State private var hotkeyPressedAt: Date?
-
-    /// Abaixo disso o atalho conta como toque, não como "segurar".
-    private static let tapThreshold: TimeInterval = 0.4
-
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $selection, isCollapsed: $isSidebarCollapsed)
@@ -82,6 +77,7 @@ struct NotetakerShell: View {
             DictationView(
                 session: dictation,
                 hotkey: settings.hotkey,
+                hotkeyMode: settings.hotkeyMode,
                 onToggle: toggleDictation
             )
         case .notetaker:
@@ -130,9 +126,6 @@ struct NotetakerShell: View {
 
     /// Atalho global = ditado: é o único que precisa funcionar de dentro de
     /// outro app. Reunião e arquivo são acionados pela própria janela.
-    ///
-    /// Segurar → grava enquanto segura, solta e escreve.
-    /// Toque curto → trava gravando; o toque seguinte encerra e escreve.
     private func hotkeyPressed() {
         guard !model.phase.isRunning else { return }
 
@@ -140,18 +133,12 @@ struct NotetakerShell: View {
             finishDictation()
             return
         }
-        hotkeyPressedAt = Date()
         startDictation()
     }
 
     private func hotkeyReleased() {
-        guard dictation.isRunning, let pressedAt = hotkeyPressedAt else { return }
-        if Date().timeIntervalSince(pressedAt) < Self.tapThreshold {
-            dictation.isLatched = true // toque curto: segue ouvindo
-        } else {
-            finishDictation()
-        }
-        hotkeyPressedAt = nil
+        guard settings.hotkeyMode == .hold, dictation.isRunning else { return }
+        finishDictation()
     }
 
     private func toggleDictation() {

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -38,6 +38,14 @@ struct NotetakerShell: View {
         .onAppear { registerHotkeys() }
         .onChange(of: settings.hotkey) { _, _ in registerHotkeys() }
         .onChange(of: settings.pushToTalkHotkey) { _, _ in registerHotkeys() }
+        .onChange(of: HotkeyCapture.shared.isCapturing) { _, isCapturing in
+            if isCapturing {
+                toggleHotkey.unregister()
+                pushToTalkHotkey.unregister()
+            } else {
+                registerHotkeys()
+            }
+        }
         .onChange(of: dictation.state) { _, state in
             guard case .failed(let message) = state else { return }
             island.isSessionActive = false
@@ -119,11 +127,19 @@ struct NotetakerShell: View {
     }
 
     private func registerHotkeys() {
-        toggleHotkey.register(
-            settings.hotkey,
-            onPress: { toggleDictation() },
-            onRelease: {}
-        )
+        if settings.hotkey.isFunctionKey || settings.pushToTalkHotkey.isFunctionKey {
+            GlobeKeyAction.disableIfNeeded()
+        }
+
+        guard !HotkeyCapture.shared.isCapturing else { return }
+
+        if settings.hotkey != settings.pushToTalkHotkey {
+            toggleHotkey.register(
+                settings.hotkey,
+                onPress: { toggleDictation() },
+                onRelease: {}
+            )
+        }
         pushToTalkHotkey.register(
             settings.pushToTalkHotkey,
             onPress: { pushToTalkPressed() },

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -39,9 +39,6 @@ struct NotetakerShell: View {
         .id(settings.localeIdentifier)
         .frame(minWidth: 1_060, minHeight: 700)
         .background(Theme.canvas)
-        // paleta do Theme é clara e fixa; sem isto sheets, campos e pickers
-        // herdam o dark do sistema e viram texto escuro sobre fundo escuro
-        .preferredColorScheme(.light)
         .onAppear { registerHotkey() }
         .onChange(of: settings.hotkey) { _, _ in registerHotkey() }
         .onChange(of: dictation.state) { _, state in

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -51,10 +51,17 @@ struct NotetakerShell: View {
             island.flashWarning(String(message.prefix(28)))
             playFeedback(.warning)
         }
-        .onChange(of: dictation.undelivered) { _, dictated in
-            guard let dictated else { return }
-            island.showResult(dictated.text)
-            playFeedback(.warning)
+        .onChange(of: dictation.outcome) { _, outcome in
+            guard let outcome else { return }
+            if outcome.needsCopy {
+                island.showResult(outcome.text)
+                playFeedback(.warning)
+            } else {
+                island.isVisible = false
+                if !outcome.text.isEmpty {
+                    playFeedback(.finish)
+                }
+            }
         }
         .onChange(of: model.phase) { _, phase in
             guard case .failed = phase else { return }
@@ -165,15 +172,9 @@ struct NotetakerShell: View {
     }
 
     private func finishDictation() {
-        let hadTarget = dictation.hasEditableTarget
-        let spoke = !dictation.liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         dictation.finish()
         island.isSessionActive = false
         island.warning = nil
-        island.isVisible = false
-        if spoke, hadTarget {
-            playFeedback(.finish)
-        }
     }
 
     private func playFeedback(_ kind: Feedback.Kind) {

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -7,7 +7,8 @@ struct NotetakerShell: View {
     @State private var selection: NavSection = .dictation
     @State private var settings = AppSettings()
     @State private var island = IslandController()
-    @State private var hotkey = GlobalHotkey()
+    @State private var toggleHotkey = GlobalHotkey(id: 1)
+    @State private var pushToTalkHotkey = GlobalHotkey(id: 2)
     @State private var dictation = DictationSession()
     @State private var files = FileTranscriptionModel()
     @State private var snippets = SnippetStore()
@@ -15,12 +16,6 @@ struct NotetakerShell: View {
     @State private var meetings: [Meeting] = []
     @State private var meetingStartedAt: Date?
     @State private var elapsed: TimeInterval = 0
-    @State private var pressedAt: Date?
-    @State private var isLatched = false
-    @State private var secondTapWindow: Task<Void, Never>?
-
-    /// Acima disso o atalho conta como "segurar", não como toque.
-    private static let tapThreshold: TimeInterval = 0.35
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $selection, isCollapsed: $isSidebarCollapsed)
@@ -40,8 +35,9 @@ struct NotetakerShell: View {
         .id(settings.localeIdentifier)
         .frame(minWidth: 1_060, minHeight: 700)
         .background(Theme.canvas)
-        .onAppear { registerHotkey() }
-        .onChange(of: settings.hotkey) { _, _ in registerHotkey() }
+        .onAppear { registerHotkeys() }
+        .onChange(of: settings.hotkey) { _, _ in registerHotkeys() }
+        .onChange(of: settings.pushToTalkHotkey) { _, _ in registerHotkeys() }
         .onChange(of: dictation.state) { _, state in
             guard case .failed(let message) = state else { return }
             island.isSessionActive = false
@@ -83,6 +79,7 @@ struct NotetakerShell: View {
             DictationView(
                 session: dictation,
                 hotkey: settings.hotkey,
+                pushToTalkHotkey: settings.pushToTalkHotkey,
                 onToggle: toggleDictation
             )
         case .notetaker:
@@ -121,57 +118,27 @@ struct NotetakerShell: View {
         }
     }
 
-    private func registerHotkey() {
-        hotkey.register(
+    private func registerHotkeys() {
+        toggleHotkey.register(
             settings.hotkey,
-            onPress: { hotkeyPressed() },
-            onRelease: { hotkeyReleased() }
+            onPress: { toggleDictation() },
+            onRelease: {}
+        )
+        pushToTalkHotkey.register(
+            settings.pushToTalkHotkey,
+            onPress: { pushToTalkPressed() },
+            onRelease: { pushToTalkReleased() }
         )
     }
 
-    /// Atalho global = ditado: é o único que precisa funcionar de dentro de
-    /// outro app. Reunião e arquivo são acionados pela própria janela.
-    private func hotkeyPressed() {
-        guard !model.phase.isRunning else { return }
-
-        if isLatched {
-            isLatched = false
-            secondTapWindow?.cancel()
-            secondTapWindow = nil
-            finishDictation()
-            return
-        }
-
-        if dictation.isRunning, secondTapWindow != nil {
-            secondTapWindow?.cancel()
-            secondTapWindow = nil
-            isLatched = true
-            return
-        }
-
-        pressedAt = Date()
+    private func pushToTalkPressed() {
+        guard !model.phase.isRunning, !dictation.isRunning else { return }
         startDictation()
     }
 
-    /// Soltar rápido não encerra na hora: é preciso dar tempo do segundo toque
-    /// chegar, senão o duplo toque nunca aconteceria.
-    private func hotkeyReleased() {
-        guard dictation.isRunning, let pressedAt else { return }
-        let held = Date().timeIntervalSince(pressedAt)
-        self.pressedAt = nil
-
-        guard held < Self.tapThreshold else {
-            finishDictation()
-            return
-        }
-
-        secondTapWindow = Task {
-            try? await Task.sleep(for: .milliseconds(340))
-            guard !Task.isCancelled else { return }
-            secondTapWindow = nil
-            guard !isLatched else { return }
-            finishDictation()
-        }
+    private func pushToTalkReleased() {
+        guard dictation.isRunning else { return }
+        finishDictation()
     }
 
     private func toggleDictation() {
@@ -192,7 +159,6 @@ struct NotetakerShell: View {
     }
 
     private func finishDictation() {
-        isLatched = false
         dictation.finish()
         island.isSessionActive = false
         island.warning = nil

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -53,6 +53,7 @@ struct NotetakerShell: View {
         }
         .onChange(of: dictation.outcome) { _, outcome in
             guard let outcome else { return }
+            island.isProcessing = false
             if outcome.needsCopy {
                 island.showResult(outcome.text)
                 playFeedback(.warning)
@@ -175,6 +176,7 @@ struct NotetakerShell: View {
         dictation.finish()
         island.isSessionActive = false
         island.warning = nil
+        island.isProcessing = true
     }
 
     private func playFeedback(_ kind: Feedback.Kind) {

--- a/Sources/SpeechMD/Notetaker/SidebarView.swift
+++ b/Sources/SpeechMD/Notetaker/SidebarView.swift
@@ -104,7 +104,6 @@ private struct NavRow: View {
                     .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
                     .frame(width: 19)
                     .scaleEffect(isSelected ? 1.06 : 1)
-                    .symbolEffect(.bounce, options: .speed(1.4), isActive: isSelected)
                 if !isCollapsed {
                     Text(section.rawValue)
                         .font(.system(size: 14, weight: isSelected ? .semibold : .regular))

--- a/Sources/SpeechMD/Notetaker/SidebarView.swift
+++ b/Sources/SpeechMD/Notetaker/SidebarView.swift
@@ -84,7 +84,7 @@ struct SidebarView: View {
         }
         .buttonStyle(.plain)
         .pointerStyle(.link)
-        .help(isCollapsed ? "Expandir barra lateral" : "Recolher barra lateral")
+        .help(isCollapsed ? t("Expandir barra lateral", "Expand sidebar") : t("Recolher barra lateral", "Collapse sidebar"))
     }
 }
 
@@ -105,7 +105,7 @@ private struct NavRow: View {
                     .frame(width: 19)
                     .scaleEffect(isSelected ? 1.06 : 1)
                 if !isCollapsed {
-                    Text(section.rawValue)
+                    Text(section.title)
                         .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
                         .fixedSize()
                     Spacer(minLength: 0)
@@ -132,7 +132,7 @@ private struct NavRow: View {
         .pointerStyle(.link)
         .onHover { isHovering = $0 }
         .animation(.easeOut(duration: 0.14), value: isHovering)
-        .help(isCollapsed ? section.rawValue : "")
+        .help(isCollapsed ? section.title : "")
     }
 }
 

--- a/Sources/SpeechMD/Notetaker/SidebarView.swift
+++ b/Sources/SpeechMD/Notetaker/SidebarView.swift
@@ -12,8 +12,8 @@ struct SidebarView: View {
         VStack(alignment: .leading, spacing: 0) {
             brand
                 .padding(.horizontal, isCollapsed ? 0 : 20)
-                .padding(.top, 18)
-                .padding(.bottom, 22)
+                .padding(.top, isCollapsed ? 52 : 18)
+                .padding(.bottom, isCollapsed ? 8 : 22)
                 .frame(maxWidth: .infinity, alignment: isCollapsed ? .center : .leading)
 
             VStack(spacing: 2) {
@@ -49,7 +49,7 @@ struct SidebarView: View {
         .background(Theme.sidebarBackground)
         .overlay(alignment: .topTrailing) {
             collapseToggle
-                .padding(.top, 16)
+                .padding(.top, isCollapsed ? 48 : 16)
                 .padding(.trailing, isCollapsed ? 0 : 10)
                 .frame(maxWidth: isCollapsed ? .infinity : nil, alignment: isCollapsed ? .center : .trailing)
         }

--- a/Sources/SpeechMD/Notetaker/Theme.swift
+++ b/Sources/SpeechMD/Notetaker/Theme.swift
@@ -1,21 +1,35 @@
+import AppKit
 import SwiftUI
 
 /// Tokens visuais do notetaker. Trocar a paleta inteira acontece aqui.
 enum Theme {
-    static let sidebarBackground = Color(red: 0.96, green: 0.95, blue: 0.94)
-    static let canvas = Color(red: 0.99, green: 0.99, blue: 0.98)
-    static let surface = Color.white
-    static let surfaceHover = Color(red: 0.97, green: 0.96, blue: 0.95)
+    static let sidebarBackground = color(light: (0.96, 0.95, 0.94), dark: (0.11, 0.11, 0.10))
+    static let canvas = color(light: (0.99, 0.99, 0.98), dark: (0.075, 0.075, 0.07))
+    static let surface = color(light: (1, 1, 1), dark: (0.145, 0.145, 0.14))
+    static let surfaceHover = color(light: (0.97, 0.96, 0.95), dark: (0.19, 0.19, 0.18))
 
-    static let textPrimary = Color(red: 0.11, green: 0.10, blue: 0.09)
-    static let textSecondary = Color(red: 0.42, green: 0.40, blue: 0.38)
-    static let textTertiary = Color(red: 0.62, green: 0.60, blue: 0.58)
+    static let textPrimary = color(light: (0.11, 0.10, 0.09), dark: (0.96, 0.95, 0.94))
+    static let textSecondary = color(light: (0.42, 0.40, 0.38), dark: (0.68, 0.67, 0.65))
+    static let textTertiary = color(light: (0.62, 0.60, 0.58), dark: (0.50, 0.49, 0.47))
 
-    static let border = Color(red: 0.89, green: 0.88, blue: 0.86)
-    static let accent = Color(red: 0.45, green: 0.28, blue: 0.83)
-    static let highlight = Color(red: 0.98, green: 0.72, blue: 0.28)
-    static let live = Color(red: 0.90, green: 0.26, blue: 0.24)
+    static let border = color(light: (0.89, 0.88, 0.86), dark: (0.25, 0.25, 0.24))
+    static let accent = color(light: (0.45, 0.28, 0.83), dark: (0.64, 0.50, 0.96))
+    static let highlight = color(light: (0.98, 0.72, 0.28), dark: (0.98, 0.76, 0.36))
+    static let live = color(light: (0.90, 0.26, 0.24), dark: (0.95, 0.38, 0.35))
+
+    /// Fundo dos cards pretos, com `.white` por cima nos dois temas.
+    static let contrastSurface = color(light: (0.11, 0.10, 0.09), dark: (0.17, 0.17, 0.16))
 
     static let cornerRadius: CGFloat = 12
     static let cardRadius: CGFloat = 16
+
+    private static func color(
+        light: (Double, Double, Double),
+        dark: (Double, Double, Double)
+    ) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            let tone = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+            return NSColor(srgbRed: tone.0, green: tone.1, blue: tone.2, alpha: 1)
+        })
+    }
 }

--- a/Sources/SpeechMD/Settings/AppAppearance.swift
+++ b/Sources/SpeechMD/Settings/AppAppearance.swift
@@ -1,0 +1,40 @@
+import AppKit
+
+enum AppAppearance: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .system: t("Sistema", "System")
+        case .light: t("Claro", "Light")
+        case .dark: t("Escuro", "Dark")
+        }
+    }
+
+    @MainActor
+    func apply() {
+        switch self {
+        case .system: NSApp.appearance = nil
+        case .light: NSApp.appearance = NSAppearance(named: .aqua)
+        case .dark: NSApp.appearance = NSAppearance(named: .darkAqua)
+        }
+    }
+}
+
+enum HotkeyMode: String, CaseIterable, Identifiable {
+    case toggle
+    case hold
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .toggle: t("Clicar e gravar", "Click and record")
+        case .hold: t("Pressione para falar", "Push to talk")
+        }
+    }
+}

--- a/Sources/SpeechMD/Settings/AppAppearance.swift
+++ b/Sources/SpeechMD/Settings/AppAppearance.swift
@@ -24,17 +24,3 @@ enum AppAppearance: String, CaseIterable, Identifiable {
         }
     }
 }
-
-enum HotkeyMode: String, CaseIterable, Identifiable {
-    case toggle
-    case hold
-
-    var id: Self { self }
-
-    var label: String {
-        switch self {
-        case .toggle: t("Clicar e gravar", "Click and record")
-        case .hold: t("Pressione para falar", "Push to talk")
-        }
-    }
-}

--- a/Sources/SpeechMD/Settings/AppSettings.swift
+++ b/Sources/SpeechMD/Settings/AppSettings.swift
@@ -10,6 +10,10 @@ final class AppSettings {
         didSet { save(hotkey, forKey: Keys.hotkey) }
     }
 
+    var pushToTalkHotkey: HotkeyBinding {
+        didSet { save(pushToTalkHotkey, forKey: Keys.pushToTalkHotkey) }
+    }
+
     var localeIdentifier: String {
         didSet {
             defaults.set(localeIdentifier, forKey: Keys.locale)
@@ -52,6 +56,7 @@ final class AppSettings {
 
     init() {
         hotkey = Self.load(HotkeyBinding.self, forKey: Keys.hotkey) ?? .default
+        pushToTalkHotkey = Self.load(HotkeyBinding.self, forKey: Keys.pushToTalkHotkey) ?? .fn
         localeIdentifier = defaults.string(forKey: Keys.locale) ?? "pt-BR"
         appearance = defaults.string(forKey: Keys.appearance)
             .flatMap(AppAppearance.init(rawValue:)) ?? .system
@@ -78,6 +83,7 @@ final class AppSettings {
 
     private enum Keys {
         static let hotkey = "hotkey"
+        static let pushToTalkHotkey = "pushToTalkHotkey"
         static let locale = "localeIdentifier"
         static let appearance = "appearance"
         static let recognitionMode = "recognitionMode"

--- a/Sources/SpeechMD/Settings/AppSettings.swift
+++ b/Sources/SpeechMD/Settings/AppSettings.swift
@@ -10,7 +10,10 @@ final class AppSettings {
     }
 
     var localeIdentifier: String {
-        didSet { defaults.set(localeIdentifier, forKey: Keys.locale) }
+        didSet {
+            defaults.set(localeIdentifier, forKey: Keys.locale)
+            Language.isEnglish = Language.matches(localeIdentifier: localeIdentifier)
+        }
     }
 
     var recognitionMode: RecognitionMode {
@@ -49,6 +52,7 @@ final class AppSettings {
         formatAsMarkdown = defaults.object(forKey: Keys.formatAsMarkdown) as? Bool ?? false
         soundFeedback = defaults.object(forKey: Keys.soundFeedback) as? Bool ?? true
         hapticFeedback = defaults.object(forKey: Keys.hapticFeedback) as? Bool ?? true
+        Language.isEnglish = Language.matches(localeIdentifier: localeIdentifier)
     }
 
     private func save<T: Encodable>(_ value: T, forKey key: String) {

--- a/Sources/SpeechMD/Settings/AppSettings.swift
+++ b/Sources/SpeechMD/Settings/AppSettings.swift
@@ -24,10 +24,6 @@ final class AppSettings {
         }
     }
 
-    var hotkeyMode: HotkeyMode {
-        didSet { defaults.set(hotkeyMode.rawValue, forKey: Keys.hotkeyMode) }
-    }
-
     var recognitionMode: RecognitionMode {
         didSet { defaults.set(recognitionMode.rawValue, forKey: Keys.recognitionMode) }
     }
@@ -59,8 +55,6 @@ final class AppSettings {
         localeIdentifier = defaults.string(forKey: Keys.locale) ?? "pt-BR"
         appearance = defaults.string(forKey: Keys.appearance)
             .flatMap(AppAppearance.init(rawValue:)) ?? .system
-        hotkeyMode = defaults.string(forKey: Keys.hotkeyMode)
-            .flatMap(HotkeyMode.init(rawValue:)) ?? .toggle
         recognitionMode = defaults.string(forKey: Keys.recognitionMode)
             .flatMap(RecognitionMode.init(rawValue:)) ?? .lowLatency
         captureSystemAudio = defaults.object(forKey: Keys.captureSystemAudio) as? Bool ?? true
@@ -86,7 +80,6 @@ final class AppSettings {
         static let hotkey = "hotkey"
         static let locale = "localeIdentifier"
         static let appearance = "appearance"
-        static let hotkeyMode = "hotkeyMode"
         static let recognitionMode = "recognitionMode"
         static let captureSystemAudio = "captureSystemAudio"
         static let showIsland = "showIsland"

--- a/Sources/SpeechMD/Settings/AppSettings.swift
+++ b/Sources/SpeechMD/Settings/AppSettings.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -14,6 +15,17 @@ final class AppSettings {
             defaults.set(localeIdentifier, forKey: Keys.locale)
             Language.isEnglish = Language.matches(localeIdentifier: localeIdentifier)
         }
+    }
+
+    var appearance: AppAppearance {
+        didSet {
+            defaults.set(appearance.rawValue, forKey: Keys.appearance)
+            appearance.apply()
+        }
+    }
+
+    var hotkeyMode: HotkeyMode {
+        didSet { defaults.set(hotkeyMode.rawValue, forKey: Keys.hotkeyMode) }
     }
 
     var recognitionMode: RecognitionMode {
@@ -45,6 +57,10 @@ final class AppSettings {
     init() {
         hotkey = Self.load(HotkeyBinding.self, forKey: Keys.hotkey) ?? .default
         localeIdentifier = defaults.string(forKey: Keys.locale) ?? "pt-BR"
+        appearance = defaults.string(forKey: Keys.appearance)
+            .flatMap(AppAppearance.init(rawValue:)) ?? .system
+        hotkeyMode = defaults.string(forKey: Keys.hotkeyMode)
+            .flatMap(HotkeyMode.init(rawValue:)) ?? .toggle
         recognitionMode = defaults.string(forKey: Keys.recognitionMode)
             .flatMap(RecognitionMode.init(rawValue:)) ?? .lowLatency
         captureSystemAudio = defaults.object(forKey: Keys.captureSystemAudio) as? Bool ?? true
@@ -53,6 +69,7 @@ final class AppSettings {
         soundFeedback = defaults.object(forKey: Keys.soundFeedback) as? Bool ?? true
         hapticFeedback = defaults.object(forKey: Keys.hapticFeedback) as? Bool ?? true
         Language.isEnglish = Language.matches(localeIdentifier: localeIdentifier)
+        appearance.apply()
     }
 
     private func save<T: Encodable>(_ value: T, forKey key: String) {
@@ -68,6 +85,8 @@ final class AppSettings {
     private enum Keys {
         static let hotkey = "hotkey"
         static let locale = "localeIdentifier"
+        static let appearance = "appearance"
+        static let hotkeyMode = "hotkeyMode"
         static let recognitionMode = "recognitionMode"
         static let captureSystemAudio = "captureSystemAudio"
         static let showIsland = "showIsland"

--- a/Sources/SpeechMD/Settings/GlobalHotkey.swift
+++ b/Sources/SpeechMD/Settings/GlobalHotkey.swift
@@ -6,6 +6,12 @@ import Carbon.HIToolbox
 /// que a tecla fn, que o Carbon não registra, depende dela.
 @MainActor
 final class GlobalHotkey {
+    private let id: UInt32
+
+    init(id: UInt32) {
+        self.id = id
+    }
+
     private var hotKeyRef: EventHotKeyRef?
     private var eventHandler: EventHandlerRef?
     private var flagsMonitors: [Any] = []
@@ -13,7 +19,7 @@ final class GlobalHotkey {
     private var onPress: (() -> Void)?
     private var onRelease: (() -> Void)?
 
-    private static let signature = OSType(0x53504348) // 'SPCH'
+    fileprivate static let signature = OSType(0x53504348) // 'SPCH'
 
     func register(
         _ binding: HotkeyBinding,
@@ -35,7 +41,7 @@ final class GlobalHotkey {
         RegisterEventHotKey(
             binding.keyCode,
             carbonModifiers(from: binding.modifierFlags),
-            EventHotKeyID(signature: Self.signature, id: 1),
+            EventHotKeyID(signature: Self.signature, id: id),
             GetEventDispatcherTarget(),
             0,
             &hotKeyRef
@@ -92,6 +98,21 @@ final class GlobalHotkey {
             { _, event, userData in
                 guard let userData else { return noErr }
                 let hotkey = Unmanaged<GlobalHotkey>.fromOpaque(userData).takeUnretainedValue()
+
+                var fired = EventHotKeyID()
+                GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &fired
+                )
+                guard fired.signature == GlobalHotkey.signature, fired.id == hotkey.id else {
+                    return OSStatus(eventNotHandledErr)
+                }
+
                 let isRelease = GetEventKind(event) == UInt32(kEventHotKeyReleased)
                 DispatchQueue.main.async {
                     MainActor.assumeIsolated {

--- a/Sources/SpeechMD/Settings/GlobalHotkey.swift
+++ b/Sources/SpeechMD/Settings/GlobalHotkey.swift
@@ -2,11 +2,14 @@ import AppKit
 import Carbon.HIToolbox
 
 /// Atalho global via Carbon. É a única rota que dispensa a permissão de
-/// Acessibilidade — `NSEvent.addGlobalMonitorForEvents` exigiria.
+/// Acessibilidade — `NSEvent.addGlobalMonitorForEvents` exigiria, e é por isso
+/// que a tecla fn, que o Carbon não registra, depende dela.
 @MainActor
 final class GlobalHotkey {
     private var hotKeyRef: EventHotKeyRef?
     private var eventHandler: EventHandlerRef?
+    private var flagsMonitors: [Any] = []
+    private var isFunctionKeyDown = false
     private var onPress: (() -> Void)?
     private var onRelease: (() -> Void)?
 
@@ -21,6 +24,11 @@ final class GlobalHotkey {
         guard binding.isValid else { return }
         self.onPress = onPress
         self.onRelease = onRelease
+
+        guard !binding.isFunctionKey else {
+            observeFunctionKey()
+            return
+        }
 
         installHandlerIfNeeded()
 
@@ -38,6 +46,29 @@ final class GlobalHotkey {
         if let hotKeyRef {
             UnregisterEventHotKey(hotKeyRef)
             self.hotKeyRef = nil
+        }
+        flagsMonitors.forEach(NSEvent.removeMonitor)
+        flagsMonitors = []
+        isFunctionKeyDown = false
+    }
+
+    private func observeFunctionKey() {
+        let handle: (NSEvent) -> Void = { [weak self] event in
+            guard let self, event.keyCode == HotkeyBinding.fnKeyCode else { return }
+            let isDown = event.modifierFlags.contains(.function)
+            guard isDown != isFunctionKeyDown else { return }
+            isFunctionKeyDown = isDown
+            isDown ? onPress?() : onRelease?()
+        }
+
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, handler: handle) {
+            flagsMonitors.append(global)
+        }
+        if let local = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged, handler: { event in
+            handle(event)
+            return event
+        }) {
+            flagsMonitors.append(local)
         }
     }
 

--- a/Sources/SpeechMD/Settings/GlobeKeyAction.swift
+++ b/Sources/SpeechMD/Settings/GlobeKeyAction.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A ação da tecla 🌐 é resolvida pelo sistema antes de qualquer app ver o
+/// evento, então usar fn como atalho exige desligá-la nos ajustes globais.
+enum GlobeKeyAction {
+    static var isDisabled: Bool {
+        let value = CFPreferencesCopyValue(
+            "AppleFnUsageType" as CFString,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        ) as? Int
+        return value == 0
+    }
+
+    static func disable() {
+        CFPreferencesSetValue(
+            "AppleFnUsageType" as CFString,
+            0 as CFNumber,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        )
+        CFPreferencesSynchronize(
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        )
+    }
+}

--- a/Sources/SpeechMD/Settings/GlobeKeyAction.swift
+++ b/Sources/SpeechMD/Settings/GlobeKeyAction.swift
@@ -13,7 +13,9 @@ enum GlobeKeyAction {
         return value == 0
     }
 
-    static func disable() {
+    static func disableIfNeeded() {
+        guard !isDisabled else { return }
+
         CFPreferencesSetValue(
             "AppleFnUsageType" as CFString,
             0 as CFNumber,

--- a/Sources/SpeechMD/Settings/HotkeyBinding.swift
+++ b/Sources/SpeechMD/Settings/HotkeyBinding.swift
@@ -9,12 +9,19 @@ struct HotkeyBinding: Equatable, Codable {
     /// ⌥⌘R. Space com ⌘ é da busca do sistema e nunca chegaria ao app.
     static let `default` = HotkeyBinding(keyCode: 15, modifiers: NSEvent.ModifierFlags([.option, .command]).rawValue)
 
+    static let fnKeyCode: UInt32 = 63
+
+    static let fn = HotkeyBinding(keyCode: fnKeyCode, modifiers: 0)
+
+    var isFunctionKey: Bool { keyCode == Self.fnKeyCode }
+
     var modifierFlags: NSEvent.ModifierFlags {
         NSEvent.ModifierFlags(rawValue: modifiers)
     }
 
     /// "⌥⌘Space" — ordem igual à dos menus do sistema.
     var displayString: String {
+        if isFunctionKey { return "fn" }
         var result = ""
         if modifierFlags.contains(.control) { result += "⌃" }
         if modifierFlags.contains(.option) { result += "⌥" }
@@ -24,7 +31,8 @@ struct HotkeyBinding: Equatable, Codable {
     }
 
     var isValid: Bool {
-        !modifierFlags.intersection([.control, .option, .shift, .command]).isEmpty
+        if isFunctionKey { return true }
+        return !modifierFlags.intersection([.control, .option, .shift, .command]).isEmpty
     }
 
     private static func keyName(for keyCode: UInt32) -> String {

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -4,11 +4,7 @@ struct SettingsView: View {
     @Bindable var settings: AppSettings
 
     @State private var permissionsRefreshedAt = Date()
-    @State private var isGlobeDisabled = GlobeKeyAction.isDisabled
 
-    private var usesFunctionKey: Bool {
-        settings.hotkey.isFunctionKey || settings.pushToTalkHotkey.isFunctionKey
-    }
 
     var body: some View {
         ScrollView {
@@ -42,22 +38,6 @@ struct SettingsView: View {
                         subtitle: t("Um toque começa, o toque seguinte encerra e cola o texto.", "One tap starts, the next stops and pastes the text.")
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
-                    }
-
-                    if usesFunctionKey, !isGlobeDisabled {
-                        Divider().overlay(Theme.border)
-
-                        SettingsRow(
-                            title: t("Ação da tecla 🌐", "Globe key action"),
-                            subtitle: t("O macOS abre o painel de emoji ao pressionar fn, e isso atropela o atalho. Desligar exige sair e entrar na conta.", "macOS opens the emoji panel when fn is pressed, which fights the shortcut. Turning it off requires logging out and back in.")
-                        ) {
-                            Button(t("Desligar", "Turn off")) {
-                                GlobeKeyAction.disable()
-                                isGlobeDisabled = true
-                            }
-                            .controlSize(.large)
-                            .pointerStyle(.link)
-                        }
                     }
                 }
 

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -171,7 +171,7 @@ private struct PermissionRow: View {
                         .foregroundStyle(.white)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 7)
-                        .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                 }
                 .buttonStyle(.plain)
                 .pointerStyle(.link)

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -8,11 +8,11 @@ struct SettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 22) {
-                Text("Configurações")
+                Text(t("Configurações", "Settings"))
                     .font(.system(size: 25, weight: .semibold))
                     .foregroundStyle(Theme.textPrimary)
 
-                SettingsGroup("Permissões") {
+                SettingsGroup(t("Permissões", "Permissions")) {
                     ForEach(Array(SystemPermission.allCases.enumerated()), id: \.element.id) { index, permission in
                         if index > 0 {
                             Divider().overlay(Theme.border)
@@ -22,19 +22,19 @@ struct SettingsView: View {
                 }
                 .id(permissionsRefreshedAt)
 
-                SettingsGroup("Atalho") {
+                SettingsGroup(t("Atalho", "Shortcut")) {
                     SettingsRow(
-                        title: "Iniciar e parar gravação",
-                        subtitle: "Funciona com qualquer app em foco."
+                        title: t("Iniciar e parar gravação", "Start and stop recording"),
+                        subtitle: t("Funciona com qualquer app em foco.", "Works with any focused app.")
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
                     }
                 }
 
-                SettingsGroup("Transcrição") {
+                SettingsGroup(t("Transcrição", "Transcription")) {
                     SettingsRow(
-                        title: "Idioma",
-                        subtitle: "Modelo baixado sob demanda, roda no dispositivo."
+                        title: t("Idioma da fala", "Spoken language"),
+                        subtitle: t("O idioma que você fala. Não traduz: falar português com inglês selecionado sai embaralhado. O modelo é baixado sob demanda e roda no dispositivo.", "The language you speak. It does not translate: speaking Portuguese with English selected comes out scrambled. The model downloads on demand and runs on device.")
                     ) {
                         Picker("", selection: $settings.localeIdentifier) {
                             Text("Português (BR)").tag("pt-BR")
@@ -48,8 +48,8 @@ struct SettingsView: View {
                     Divider().overlay(Theme.border)
 
                     SettingsRow(
-                        title: "Modo",
-                        subtitle: "Latência menor ou transcrição mais precisa."
+                        title: t("Modo", "Mode"),
+                        subtitle: t("Latência menor ou transcrição mais precisa.", "Lower latency or more accurate transcription.")
                     ) {
                         Picker("", selection: $settings.recognitionMode) {
                             ForEach(RecognitionMode.allCases) { mode in
@@ -61,12 +61,12 @@ struct SettingsView: View {
                     }
                 }
 
-                SettingsGroup("Formatação") {
+                SettingsGroup(t("Formatação", "Formatting")) {
                     SettingsRow(
-                        title: "Escrever em Markdown",
+                        title: t("Escrever em Markdown", "Write in Markdown"),
                         subtitle: TranscriptFormatter.isAvailable
-                            ? "Enumerações viram lista e a pontuação é corrigida por um modelo no dispositivo. Adiciona cerca de 1s antes de colar."
-                            : "Indisponível: requer Apple Intelligence ativa neste Mac."
+                            ? t("Enumerações viram lista e a pontuação é corrigida por um modelo no dispositivo. Adiciona cerca de 1s antes de colar.", "Enumerations become a list and punctuation is fixed by an on-device model. Adds about 1s before pasting.")
+                            : t("Indisponível: requer Apple Intelligence ativa neste Mac.", "Unavailable: requires Apple Intelligence enabled on this Mac.")
                     ) {
                         Toggle("", isOn: $settings.formatAsMarkdown)
                             .labelsHidden()
@@ -75,10 +75,10 @@ struct SettingsView: View {
                     }
                 }
 
-                SettingsGroup("Retorno") {
+                SettingsGroup(t("Retorno", "Feedback")) {
                     SettingsRow(
-                        title: "Som",
-                        subtitle: "Um toque ao começar a ouvir e outro ao escrever."
+                        title: t("Som", "Sound"),
+                        subtitle: t("Um toque ao começar a ouvir e outro ao escrever.", "A tick when it starts listening and another when it writes.")
                     ) {
                         Toggle("", isOn: $settings.soundFeedback)
                             .labelsHidden()
@@ -92,8 +92,8 @@ struct SettingsView: View {
                     Divider().overlay(Theme.border)
 
                     SettingsRow(
-                        title: "Retorno tátil",
-                        subtitle: "Vibração no trackpad. Sem efeito em trackpad sem Force Touch."
+                        title: t("Retorno tátil", "Haptics"),
+                        subtitle: t("Vibração no trackpad. Sem efeito em trackpad sem Force Touch.", "Trackpad vibration. No effect on trackpads without Force Touch.")
                     ) {
                         Toggle("", isOn: $settings.hapticFeedback)
                             .labelsHidden()
@@ -105,10 +105,10 @@ struct SettingsView: View {
                     }
                 }
 
-                SettingsGroup("Captura") {
+                SettingsGroup(t("Captura", "Capture")) {
                     SettingsRow(
-                        title: "Áudio dos outros participantes",
-                        subtitle: "Grava o áudio do sistema num canal separado do seu microfone."
+                        title: t("Áudio dos outros participantes", "Audio from the other participants"),
+                        subtitle: t("Grava o áudio do sistema num canal separado do seu microfone.", "Records system audio on a channel separate from your microphone.")
                     ) {
                         Toggle("", isOn: $settings.captureSystemAudio)
                             .labelsHidden()
@@ -118,8 +118,8 @@ struct SettingsView: View {
                     Divider().overlay(Theme.border)
 
                     SettingsRow(
-                        title: "Mostrar ilha no topo da tela",
-                        subtitle: "Indicador junto ao notch enquanto a reunião grava."
+                        title: t("Mostrar ilha no topo da tela", "Show the island at the top of the screen"),
+                        subtitle: t("Indicador junto ao notch enquanto a reunião grava.", "Indicator next to the notch while recording.")
                     ) {
                         Toggle("", isOn: $settings.showIsland)
                             .labelsHidden()
@@ -159,14 +159,14 @@ private struct PermissionRow: View {
             Spacer(minLength: 12)
 
             if permission.isGranted {
-                Text("Concedida")
+                Text(t("Concedida", "Granted"))
                     .font(.system(size: 12))
                     .foregroundStyle(Theme.textTertiary)
             } else {
                 Button {
                     permission.requestIfPossible()
                 } label: {
-                    Text("Permitir")
+                    Text(t("Permitir", "Allow"))
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 14)

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -29,6 +29,36 @@ struct SettingsView: View {
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
                     }
+
+                    Divider().overlay(Theme.border)
+
+                    SettingsRow(
+                        title: t("Modo do atalho", "Shortcut mode"),
+                        subtitle: t("Pressione para falar grava enquanto a tecla está pressionada. Clicar e gravar começa num toque e para no seguinte.", "Push to talk records while the key is held. Click and record starts on one tap and stops on the next.")
+                    ) {
+                        Picker("", selection: $settings.hotkeyMode) {
+                            ForEach(HotkeyMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 168)
+                    }
+                }
+
+                SettingsGroup(t("Aparência", "Appearance")) {
+                    SettingsRow(
+                        title: t("Tema", "Theme"),
+                        subtitle: t("Sistema acompanha o ajuste do macOS.", "System follows the macOS setting.")
+                    ) {
+                        Picker("", selection: $settings.appearance) {
+                            ForEach(AppAppearance.allCases) { appearance in
+                                Text(appearance.label).tag(appearance)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 168)
+                    }
                 }
 
                 SettingsGroup(t("Transcrição", "Transcription")) {

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -24,25 +24,10 @@ struct SettingsView: View {
 
                 SettingsGroup(t("Atalho", "Shortcut")) {
                     SettingsRow(
-                        title: t("Iniciar e parar gravação", "Start and stop recording"),
-                        subtitle: t("Funciona com qualquer app em foco.", "Works with any focused app.")
+                        title: t("Tecla do ditado", "Dictation key"),
+                        subtitle: t("Segure para falar, ou toque duas vezes para gravar até o toque seguinte. Funciona com qualquer app em foco.", "Hold to talk, or double tap to record until the next tap. Works with any focused app.")
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
-                    }
-
-                    Divider().overlay(Theme.border)
-
-                    SettingsRow(
-                        title: t("Modo do atalho", "Shortcut mode"),
-                        subtitle: t("Pressione para falar grava enquanto a tecla está pressionada. Clicar e gravar começa num toque e para no seguinte.", "Push to talk records while the key is held. Click and record starts on one tap and stops on the next.")
-                    ) {
-                        Picker("", selection: $settings.hotkeyMode) {
-                            ForEach(HotkeyMode.allCases) { mode in
-                                Text(mode.label).tag(mode)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 168)
                     }
                 }
 
@@ -57,7 +42,7 @@ struct SettingsView: View {
                             }
                         }
                         .labelsHidden()
-                        .frame(width: 168)
+                        .frame(maxWidth: .infinity)
                     }
                 }
 
@@ -72,7 +57,7 @@ struct SettingsView: View {
                             Text("Español").tag("es-ES")
                         }
                         .labelsHidden()
-                        .frame(width: 168)
+                        .frame(maxWidth: .infinity)
                     }
 
                     Divider().overlay(Theme.border)
@@ -87,7 +72,7 @@ struct SettingsView: View {
                             }
                         }
                         .labelsHidden()
-                        .frame(width: 168)
+                        .frame(maxWidth: .infinity)
                     }
                 }
 
@@ -264,6 +249,7 @@ private struct SettingsRow<Control: View>: View {
             }
             Spacer(minLength: 12)
             control
+                .frame(width: 180, alignment: .trailing)
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 15)

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -4,6 +4,11 @@ struct SettingsView: View {
     @Bindable var settings: AppSettings
 
     @State private var permissionsRefreshedAt = Date()
+    @State private var isGlobeDisabled = GlobeKeyAction.isDisabled
+
+    private var usesFunctionKey: Bool {
+        settings.hotkey.isFunctionKey || settings.pushToTalkHotkey.isFunctionKey
+    }
 
     var body: some View {
         ScrollView {
@@ -24,10 +29,35 @@ struct SettingsView: View {
 
                 SettingsGroup(t("Atalho", "Shortcut")) {
                     SettingsRow(
-                        title: t("Tecla do ditado", "Dictation key"),
-                        subtitle: t("Segure para falar, ou toque duas vezes para gravar até o toque seguinte. Funciona com qualquer app em foco.", "Hold to talk, or double tap to record until the next tap. Works with any focused app.")
+                        title: t("Pressione para falar", "Push to talk"),
+                        subtitle: t("Grava enquanto a tecla estiver pressionada.", "Records while the key is held.")
+                    ) {
+                        ShortcutRecorderView(binding: $settings.pushToTalkHotkey)
+                    }
+
+                    Divider().overlay(Theme.border)
+
+                    SettingsRow(
+                        title: t("Iniciar e parar gravação", "Start and stop recording"),
+                        subtitle: t("Um toque começa, o toque seguinte encerra e cola o texto.", "One tap starts, the next stops and pastes the text.")
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
+                    }
+
+                    if usesFunctionKey, !isGlobeDisabled {
+                        Divider().overlay(Theme.border)
+
+                        SettingsRow(
+                            title: t("Ação da tecla 🌐", "Globe key action"),
+                            subtitle: t("O macOS abre o painel de emoji ao pressionar fn, e isso atropela o atalho. Desligar exige sair e entrar na conta.", "macOS opens the emoji panel when fn is pressed, which fights the shortcut. Turning it off requires logging out and back in.")
+                        ) {
+                            Button(t("Desligar", "Turn off")) {
+                                GlobeKeyAction.disable()
+                                isGlobeDisabled = true
+                            }
+                            .controlSize(.large)
+                            .pointerStyle(.link)
+                        }
                     }
                 }
 

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -12,7 +12,8 @@ struct ShortcutRecorderView: View {
 
     var body: some View {
         KeyCaptureView(isRecording: $isRecording, binding: $binding)
-            .frame(width: 150, height: 34)
+            .frame(maxWidth: .infinity)
+            .frame(height: 34)
             .background(isRecording ? Theme.accent.opacity(0.08) : Theme.surface, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 9, style: .continuous)

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -1,5 +1,16 @@
 import AppKit
+import Observation
 import SwiftUI
+
+/// Enquanto um campo grava, os atalhos globais saem do ar: um hotkey do Carbon
+/// consome a combinação antes de qualquer view, e a tecla nunca chegaria aqui.
+@MainActor
+@Observable
+final class HotkeyCapture {
+    static let shared = HotkeyCapture()
+
+    var isCapturing = false
+}
 
 /// Campo que captura a próxima combinação de teclas pressionada.
 ///
@@ -34,7 +45,10 @@ private struct KeyCaptureView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> KeyCaptureNSView {
         let view = KeyCaptureNSView()
-        view.onRecordingChange = { isRecording = $0 }
+        view.onRecordingChange = {
+            isRecording = $0
+            HotkeyCapture.shared.isCapturing = $0
+        }
         view.onCapture = { binding = $0 }
         return view
     }

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -19,17 +19,10 @@ struct ShortcutRecorderView: View {
                     .stroke(isRecording ? Theme.accent : Theme.border, lineWidth: isRecording ? 1.5 : 1)
             }
             .overlay {
-                HStack(spacing: 7) {
-                    Text(isRecording ? t("Pressione as teclas", "Press the keys") : binding.displayString)
-                        .font(.system(size: 13, weight: .medium, design: isRecording ? .default : .rounded))
-                        .foregroundStyle(isRecording ? Theme.accent : Theme.textPrimary)
-                    if !isRecording {
-                        Image(systemName: "pencil")
-                            .font(.system(size: 10))
-                            .foregroundStyle(Theme.textTertiary)
-                    }
-                }
-                .allowsHitTesting(false)
+                Text(isRecording ? t("Pressione as teclas", "Press the keys") : binding.displayString)
+                    .font(.system(size: 13, weight: .medium, design: isRecording ? .default : .rounded))
+                    .foregroundStyle(isRecording ? Theme.accent : Theme.textPrimary)
+                    .allowsHitTesting(false)
             }
     }
 }

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -68,6 +68,16 @@ final class KeyCaptureNSView: NSView {
         return true
     }
 
+    override func flagsChanged(with event: NSEvent) {
+        guard isRecording, event.keyCode == HotkeyBinding.fnKeyCode else {
+            super.flagsChanged(with: event)
+            return
+        }
+        guard event.modifierFlags.contains(.function) else { return }
+        onCapture?(.fn)
+        isRecording = false
+    }
+
     override func keyDown(with event: NSEvent) {
         guard isRecording else {
             super.keyDown(with: event)

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -20,7 +20,7 @@ struct ShortcutRecorderView: View {
             }
             .overlay {
                 HStack(spacing: 7) {
-                    Text(isRecording ? "Pressione as teclas" : binding.displayString)
+                    Text(isRecording ? t("Pressione as teclas", "Press the keys") : binding.displayString)
                         .font(.system(size: 13, weight: .medium, design: isRecording ? .default : .rounded))
                         .foregroundStyle(isRecording ? Theme.accent : Theme.textPrimary)
                     if !isRecording {

--- a/Sources/SpeechMD/Settings/SystemPermissions.swift
+++ b/Sources/SpeechMD/Settings/SystemPermissions.swift
@@ -13,17 +13,23 @@ enum SystemPermission: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .microphone: "Microfone"
-        case .screenRecording: "Gravação de tela"
-        case .accessibility: "Acessibilidade"
+        case .microphone: t("Microfone", "Microphone")
+        case .screenRecording: t("Gravação de tela", "Screen recording")
+        case .accessibility: t("Acessibilidade", "Accessibility")
         }
     }
 
     var reason: String {
         switch self {
-        case .microphone: "Transcrever a sua voz."
-        case .screenRecording: "Capturar o áudio dos outros participantes da reunião."
-        case .accessibility: "Colar o texto ditado no app em foco."
+        case .microphone: t("Transcrever a sua voz.", "Transcribe your voice.")
+        case .screenRecording: t(
+            "Capturar o áudio dos outros participantes da reunião.",
+            "Capture the audio of the other people in the meeting."
+        )
+        case .accessibility: t(
+            "Colar o texto ditado no app em foco.",
+            "Paste the dictated text into the focused app."
+        )
         }
     }
 

--- a/Sources/SpeechMD/Snippets/SnippetsView.swift
+++ b/Sources/SpeechMD/Snippets/SnippetsView.swift
@@ -66,7 +66,7 @@ struct SnippetsView: View {
                     Text(t("Novo atalho", "New shortcut"))
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .foregroundStyle(Theme.textPrimary)
+                .foregroundStyle(Theme.contrastSurface)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 9)
                 .background(.white, in: RoundedRectangle(cornerRadius: 9, style: .continuous))

--- a/Sources/SpeechMD/Snippets/SnippetsView.swift
+++ b/Sources/SpeechMD/Snippets/SnippetsView.swift
@@ -51,7 +51,7 @@ struct SnippetsView: View {
                 Text("Dicionário")
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("Fale o atalho e ele vira o texto completo — email, link, prompt que você repete sempre.")
+                Text("Fale o atalho e ele vira o texto completo: email, link, prompt que você repete sempre.")
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/SpeechMD/Snippets/SnippetsView.swift
+++ b/Sources/SpeechMD/Snippets/SnippetsView.swift
@@ -48,10 +48,10 @@ struct SnippetsView: View {
     private var header: some View {
         HStack(spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
-                Text("Dicionário")
+                Text(t("Dicionário", "Dictionary"))
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("Fale o atalho e ele vira o texto completo: email, link, prompt que você repete sempre.")
+                Text(t("Fale o atalho e ele vira o texto completo: email, link, prompt que você repete sempre.", "Speak the shortcut and it becomes the full text: email, link, a prompt you repeat all the time."))
                     .font(.system(size: 12))
                     .foregroundStyle(.white.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)
@@ -63,7 +63,7 @@ struct SnippetsView: View {
                 HStack(spacing: 7) {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .semibold))
-                    Text("Novo atalho")
+                    Text(t("Novo atalho", "New shortcut"))
                         .font(.system(size: 13, weight: .semibold))
                 }
                 .foregroundStyle(Theme.textPrimary)
@@ -84,10 +84,10 @@ struct SnippetsView: View {
             Image(systemName: "text.book.closed")
                 .font(.system(size: 26, weight: .light))
                 .foregroundStyle(Theme.textTertiary)
-            Text("Nenhum atalho cadastrado")
+            Text(t("Nenhum atalho cadastrado", "No shortcuts yet"))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Theme.textPrimary)
-            Text("Ex.: falar “meu email” vira seu endereço completo.")
+            Text(t("Ex.: falar “meu email” vira seu endereço completo.", "Example: saying “my email” becomes your full address."))
                 .font(.system(size: 13))
                 .foregroundStyle(Theme.textSecondary)
         }
@@ -154,20 +154,20 @@ private struct SnippetEditor: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
-            Text(snippet.trigger.isEmpty ? "Novo atalho" : "Editar atalho")
+            Text(snippet.trigger.isEmpty ? t("Novo atalho", "New shortcut") : t("Editar atalho", "Edit shortcut"))
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(Theme.textPrimary)
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Quando eu falar")
+                Text(t("Quando eu falar", "When I say"))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(Theme.textSecondary)
-                TextField("meu email", text: $snippet.trigger)
+                TextField(t("meu email", "my email"), text: $snippet.trigger)
                     .textFieldStyle(.roundedBorder)
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Escreva isto")
+                Text(t("Escreva isto", "Write this"))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(Theme.textSecondary)
                 TextEditor(text: $snippet.expansion)
@@ -185,9 +185,9 @@ private struct SnippetEditor: View {
 
             HStack {
                 Spacer()
-                Button("Cancelar", action: onCancel)
+                Button(t("Cancelar", "Cancel"), action: onCancel)
                     .pointerStyle(.link)
-                Button("Salvar") { onSave(snippet) }
+                Button(t("Salvar", "Save")) { onSave(snippet) }
                     .buttonStyle(.borderedProminent)
                     .pointerStyle(.link)
                     .disabled(!snippet.isValid)

--- a/Sources/SpeechMD/Snippets/SnippetsView.swift
+++ b/Sources/SpeechMD/Snippets/SnippetsView.swift
@@ -76,7 +76,7 @@ struct SnippetsView: View {
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 18)
-        .background(Theme.textPrimary, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
+        .background(Theme.contrastSurface, in: RoundedRectangle(cornerRadius: Theme.cardRadius, style: .continuous))
     }
 
     private var emptyState: some View {

--- a/Sources/SpeechMD/Snippets/SnippetsView.swift
+++ b/Sources/SpeechMD/Snippets/SnippetsView.swift
@@ -186,8 +186,10 @@ private struct SnippetEditor: View {
             HStack {
                 Spacer()
                 Button("Cancelar", action: onCancel)
+                    .pointerStyle(.link)
                 Button("Salvar") { onSave(snippet) }
                     .buttonStyle(.borderedProminent)
+                    .pointerStyle(.link)
                     .disabled(!snippet.isValid)
             }
         }

--- a/Sources/SpeechMD/Speech/SpeechPipeline.swift
+++ b/Sources/SpeechMD/Speech/SpeechPipeline.swift
@@ -11,8 +11,8 @@ enum RecognitionMode: String, CaseIterable, Identifiable, Sendable {
 
     var label: String {
         switch self {
-        case .lowLatency: "Baixa latência"
-        case .quality: "Maior precisão"
+        case .lowLatency: t("Baixa latência", "Low latency")
+        case .quality: t("Maior precisão", "Higher accuracy")
         }
     }
 }
@@ -54,11 +54,11 @@ enum SpeechPipelineError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unavailable:
-            "SpeechTranscriber não está disponível neste Mac."
+            t("SpeechTranscriber não está disponível neste Mac.", "SpeechTranscriber is not available on this Mac.")
         case .unsupportedLocale(let locale):
-            "O locale \(locale) não é suportado pelo SpeechTranscriber."
+            t("O locale \(locale) não é suportado pelo SpeechTranscriber.", "The locale \(locale) is not supported by SpeechTranscriber.")
         case .noMicrophone:
-            "Nenhum microfone foi encontrado."
+            t("Nenhum microfone foi encontrado.", "No microphone was found.")
         }
     }
 }
@@ -211,7 +211,7 @@ actor SpeechPipeline {
     private func preparePipeline() async throws -> PreparedPipeline {
         let options = SpeechAnalyzer.Options(
             priority: .high,
-            modelRetention: .processLifetime
+            modelRetention: .lingering
         )
 
         switch mode {


### PR DESCRIPTION
Stacked on #1.

## Dictation

**The island vanished before the text existed.** It was hidden the moment the hotkey was released, while the transcript was still being finalized. Delivery is now a single `DictationOutcome`: the island stays up, with a spinner, until the text is either pasted or handed to the bubble.

**The last word was being dropped.** `SpeechPipeline.stop()` called `cancelAndFinishNow()`, which discards the audio still queued in the analyzer. It now finalizes through end of input and waits for the result stream to drain.

**Nothing pasted into Electron apps.** The old check asked accessibility whether the focused element accepts text. Claude Desktop exposes no focused element at all, so it always failed. That probe is gone: if an external app was focused when you started speaking, the text is pasted there. The bubble is for the real cases of having nowhere to paste.

**Two independent shortcuts.** One for push to talk (hold), one for start/stop (tap), each with its own key, both registrable at the same time. The `fn` key works in either: Carbon cannot register a bare modifier, so `fn` bindings fall back to a `flagsChanged` monitor. While a field is capturing a new shortcut the global hotkeys are unregistered, otherwise Carbon swallows the combination before it can reach the field. When a shortcut uses `fn`, the app turns off the globe key action (`AppleFnUsageType`) so the emoji panel stops fighting it.

## Formatting

The on-device model turned a single sentence into `1.  **Teste** teste teste.` The output is now sanitized: a list marker survives only when two or more lines carry one, and bold markers are stripped.

Snippet triggers ignore punctuation, so `meu github:` matches the spoken `meu GitHub`.

## Interface

Full pt-BR/en localization driven by the spoken language, dark mode following the system appearance (with a Light/Dark/System picker), sliding sidebar selection, pointer cursor on every clickable zone, equal widths for every settings control, and an app icon.

## Performance

Idle CPU went from 0.52s per 8s to zero, by removing a `Timer.publish` that ran for the whole session to time meetings that were not happening. The speech model retention went from `.processLifetime` to `.lingering`.