### PR TITLE
Dictation modes, dark theme and a one-command install

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>0.4.0</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>NSHighResolutionCapable</key>

--- a/README.md
+++ b/README.md
@@ -48,14 +48,12 @@ targets for sustained use — first partial under 300 ms, sustained lag under
 ## Install
 
 ```sh
-brew tap Andsu-dev/tap
-brew trust andsu-dev/tap
-brew install --cask --no-quarantine speech-md
+brew install Andsu-dev/tap/speech-md
 ```
 
-`--no-quarantine` matters: the app is signed with a local certificate, not
-notarized by Apple, so Gatekeeper would otherwise ask you to right-click and
-Open on the first launch.
+The app is signed with a local certificate, not notarized by Apple. The cask
+clears the Gatekeeper quarantine flag on install, so it opens on the first
+click.
 
 Runs on Apple Silicon, macOS 26 or later.
 


### PR DESCRIPTION
## O que muda

**Ditado**
- Hold to talk e double tap pra manter gravando, com teclas separadas pra cada modo
- Tecla `fn` aceita como atalho; ação do globo desligada no launch sem perguntar
- Cola no app focado em vez de sondar a acessibilidade; bolha de cópia quando não há alvo
- Atalhos globais suspensos enquanto você grava um novo

**Interface**
- Tema escuro seguindo a aparência do sistema, escolha de tema nos ajustes
- Interface inteira troca com o idioma falado
- Ilha: anel de contagem girando, loader durante a finalização, entrega fora do body da view

**Install**
- `brew install Andsu-dev/tap/speech-md`, uma linha só. O `--no-quarantine` não existe mais no Homebrew 6, então o cask tira a quarentena no `postflight` e o usuário não roda nada
- Bump pra 0.4.0

## Teste

Build local e ditado ponta a ponta. O install novo depende do cask atualizado em `Andsu-dev/homebrew-tap` (PR separado).