### PR TITLE
Vocabulary hint, microphone picker and fn fn

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.0</string>
+    <string>0.5.0</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>5</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>NSHighResolutionCapable</key>

--- a/README.md
+++ b/README.md
@@ -19,8 +19,18 @@ side by side.
 **Files** — drop in an audio file and get a transcript, along with how many
 times faster than real time it ran.
 
+**Microphone** — pick which input device dictation and your meeting track
+listen to, or leave it on the system default.
+
 **Dictionary** — voice shortcuts: say "my email" and your full address comes
 out.
+
+**Foreign terms** — the recognizer gets a vocabulary hint before it listens
+(`AnalysisContext.contextualStrings`): the technical English people mix into
+Portuguese, plus whatever is in your dictionary. "function" comes out spelled
+right during transcription, at no latency cost. An optional second pass sends
+still-unknown words through the on-device model, one word at a time; it is off
+by default because it adds about a second before pasting.
 
 **Markdown** — optional. An on-device model (Foundation Models) reformats the
 dictation before pasting, turning spoken lists into bullets and fixing
@@ -36,6 +46,9 @@ audio generated with `say`, three runs.
 | File transcription | **75× real time** (27.7s of audio in 0.37s) |
 | Markdown formatting, 14 words | 0.62s (0.43–0.93) |
 | Markdown formatting, 56 words | 1.02s (0.90–1.12) |
+| Vocabulary hint to the recognizer | 0s (runs inside transcription) |
+| Optional term pass, 1 word | 0.28s |
+| Optional term pass, 2 words | 0.98s |
 
 Formatting only runs when enabled, and it runs *after* transcription — it adds
 latency between releasing the hotkey and the text appearing, not while you
@@ -125,7 +138,7 @@ Sources/SpeechMD/
 ├── Meetings/     two-channel meeting recording
 ├── Files/        file transcription
 ├── Snippets/     voice shortcut dictionary
-├── Formatting/   on-device Markdown pass
+├── Formatting/   on-device Markdown and foreign-term passes
 ├── Island/       floating indicator by the notch
 ├── Settings/     preferences, global hotkey, permissions
 └── Notetaker/    interface shell

--- a/Sources/SpeechMD/Dictation/DictationSession.swift
+++ b/Sources/SpeechMD/Dictation/DictationSession.swift
@@ -66,11 +66,16 @@ final class DictationSession {
     private var targetApp: NSRunningApplication?
     private var expand: (String) -> String = { $0 }
     private var formatAsMarkdown = false
+    private var polishTerms = false
+    private var localeIdentifier = "pt-BR"
 
     func start(
         localeIdentifier: String,
         mode: RecognitionMode,
+        inputDeviceUID: String = "",
+        contextualTerms: [String] = SpokenTerms.all(),
         formatAsMarkdown: Bool = false,
+        polishTerms: Bool = false,
         expand: @escaping (String) -> String = { $0 }
     ) {
         guard !isRunning else { return }
@@ -78,14 +83,23 @@ final class DictationSession {
         targetApp = frontmost?.bundleIdentifier == Bundle.main.bundleIdentifier ? nil : frontmost
         self.expand = expand
         self.formatAsMarkdown = formatAsMarkdown
+        self.polishTerms = polishTerms
+        self.localeIdentifier = localeIdentifier
         targetIssue = TargetIssue.current(target: targetApp)
+
+        if polishTerms { TermPolisher.prewarm() }
 
         state = .starting
         liveText = ""
 
         startTask = Task(priority: .userInitiated) {
             do {
-                let pipeline = SpeechPipeline(localeIdentifier: localeIdentifier, mode: mode)
+                let pipeline = SpeechPipeline(
+                    localeIdentifier: localeIdentifier,
+                    mode: mode,
+                    inputDeviceUID: inputDeviceUID.isEmpty ? nil : inputDeviceUID,
+                    contextualTerms: contextualTerms
+                )
                 self.pipeline = pipeline
                 try await pipeline.startMicrophone { [weak self] event in
                     self?.liveText = event.accumulatedText
@@ -124,6 +138,9 @@ final class DictationSession {
             }
 
             var text = expand(raw)
+            if polishTerms {
+                text = await TermPolisher.polish(text, localeIdentifier: localeIdentifier)
+            }
             if formatAsMarkdown {
                 text = await TranscriptFormatter.format(text)
             }

--- a/Sources/SpeechMD/Formatting/TermPolisher.swift
+++ b/Sources/SpeechMD/Formatting/TermPolisher.swift
@@ -1,0 +1,145 @@
+import AppKit
+import FoundationModels
+import Foundation
+
+/// Corrige a grafia de estrangeirismos que o transcritor ouve errado
+/// ("brifing" -> "briefing"), sem tocar na transcrição em si.
+///
+/// Só as palavras que o corretor do sistema não reconhece vão ao modelo, e o
+/// modelo responde palavra por palavra: a frase nunca é reescrita, então o
+/// custo é proporcional ao número de termos suspeitos, não ao tamanho do texto.
+@MainActor
+enum TermPolisher {
+    private static let instructions = """
+    Você corrige a grafia de palavras estrangeiras ditadas em voz alta.
+
+    Recebe uma palavra por linha, como o transcritor ouviu.
+    Responda uma linha por palavra, na mesma ordem, com a grafia correta no
+    idioma de origem. Exemplo: "brifing" vira "briefing".
+
+    Se a palavra já estiver correta, se for nome próprio ou se você não
+    reconhecer o termo, repita exatamente a palavra recebida.
+
+    Responda só as palavras, uma por linha, sem numeração e sem comentário.
+    """
+
+    /// No máximo isso de palavra por ditado: cada palavra a mais é token a
+    /// mais, e o custo aparece direto na espera antes de colar.
+    private static let wordLimit = 3
+
+    private static var cache: [String: String] = [:]
+    private static var session: LanguageModelSession?
+
+    static var isAvailable: Bool {
+        if case .available = SystemLanguageModel.default.availability { return true }
+        return false
+    }
+
+    /// Abre a sessão enquanto a pessoa ainda está falando, para o modelo já
+    /// estar quente na hora de colar.
+    static func prewarm() {
+        guard isAvailable else { return }
+        let session = LanguageModelSession(instructions: instructions)
+        session.prewarm()
+        self.session = session
+    }
+
+    static func polish(_ text: String, localeIdentifier: String) async -> String {
+        guard isAvailable else { return text }
+
+        let suspects = suspectWords(in: text, localeIdentifier: localeIdentifier)
+        guard !suspects.isEmpty else { return text }
+
+        let known = suspects.filter { cache[$0.lowercased()] != nil }
+        let unknown = Array(suspects.filter { cache[$0.lowercased()] == nil }.prefix(wordLimit))
+
+        if !unknown.isEmpty {
+            await learn(unknown)
+        }
+
+        var result = text
+        for word in known + unknown {
+            guard let correction = cache[word.lowercased()], correction != word.lowercased() else { continue }
+            result = replace(word, with: correction, in: result)
+        }
+        return result
+    }
+
+    private static func learn(_ words: [String]) async {
+        // A sessão do prewarm serve uma vez só: reusá-la acumularia o histórico
+        // das correções anteriores no contexto de cada ditado seguinte.
+        let session = self.session ?? LanguageModelSession(instructions: instructions)
+        self.session = nil
+
+        let options = GenerationOptions(
+            sampling: .greedy,
+            maximumResponseTokens: words.count * 8
+        )
+
+        guard let response = try? await session.respond(
+            to: words.joined(separator: "\n"),
+            options: options
+        ) else { return }
+
+        let corrections = response.content
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard corrections.count == words.count else { return }
+
+        for (word, correction) in zip(words, corrections) where accepts(correction, for: word) {
+            cache[word.lowercased()] = correction.lowercased()
+        }
+    }
+
+    /// O modelo às vezes responde uma frase, uma tradução ou uma palavra sem
+    /// relação nenhuma. Só passa o que ainda parece a mesma palavra.
+    private static func accepts(_ correction: String, for word: String) -> Bool {
+        guard correction.count >= 2,
+              correction.allSatisfy({ $0.isLetter || $0 == "-" || $0 == "'" }),
+              abs(correction.count - word.count) <= 4
+        else { return false }
+
+        return correction.first?.lowercased() == word.first?.lowercased()
+    }
+
+    /// Palavras que o dicionário do idioma não conhece. Nome próprio e gíria
+    /// caem aqui também, mas para esses o modelo devolve a mesma palavra.
+    private static func suspectWords(in text: String, localeIdentifier: String) -> [String] {
+        let checker = NSSpellChecker.shared
+        let language = localeIdentifier.replacingOccurrences(of: "-", with: "_")
+        var found: [String] = []
+        var offset = 0
+
+        while offset < text.utf16.count {
+            let range = checker.checkSpelling(
+                of: text,
+                startingAt: offset,
+                language: language,
+                wrap: false,
+                inSpellDocumentWithTag: 0,
+                wordCount: nil
+            )
+            guard range.location != NSNotFound, range.length > 0 else { break }
+            offset = range.location + range.length
+
+            guard let swiftRange = Range(range, in: text) else { continue }
+            let word = String(text[swiftRange])
+            guard word.count >= 4,
+                  word.allSatisfy(\.isLetter),
+                  !found.contains(where: { $0.lowercased() == word.lowercased() })
+            else { continue }
+            found.append(word)
+        }
+        return found
+    }
+
+    private static func replace(_ word: String, with correction: String, in text: String) -> String {
+        let cased = word.first?.isUppercase == true ? correction.capitalized : correction
+        guard let pattern = try? Regex("\\b\(NSRegularExpression.escapedPattern(for: word))\\b") else {
+            return text
+        }
+        return text.replacing(pattern, with: cased)
+    }
+}

--- a/Sources/SpeechMD/Meetings/MeetingSession.swift
+++ b/Sources/SpeechMD/Meetings/MeetingSession.swift
@@ -29,6 +29,7 @@ final class MeetingSession {
     var othersMetrics = RunMetrics.empty
     var localeIdentifier = "pt-BR"
     var recognitionMode: RecognitionMode = .lowLatency
+    var inputDeviceUID = ""
 
     private var youPipeline: SpeechPipeline?
     private var othersPipeline: SpeechPipeline?
@@ -43,7 +44,11 @@ final class MeetingSession {
         reset()
 
         runTask = Task(priority: .userInitiated) {
-            let you = SpeechPipeline(localeIdentifier: localeIdentifier, mode: recognitionMode)
+            let you = SpeechPipeline(
+                localeIdentifier: localeIdentifier,
+                mode: recognitionMode,
+                inputDeviceUID: inputDeviceUID.isEmpty ? nil : inputDeviceUID
+            )
             let others = SpeechPipeline(localeIdentifier: localeIdentifier, mode: recognitionMode)
             youPipeline = you
             othersPipeline = others
@@ -89,7 +94,11 @@ final class MeetingSession {
 
         runTask = Task(priority: .userInitiated) {
             do {
-                let you = SpeechPipeline(localeIdentifier: localeIdentifier, mode: recognitionMode)
+                let you = SpeechPipeline(
+                    localeIdentifier: localeIdentifier,
+                    mode: recognitionMode,
+                    inputDeviceUID: inputDeviceUID.isEmpty ? nil : inputDeviceUID
+                )
                 youPipeline = you
                 try await you.startMicrophone { [weak self] event in
                     self?.youTranscript = event.accumulatedText

--- a/Sources/SpeechMD/Notetaker/NotetakerShell.swift
+++ b/Sources/SpeechMD/Notetaker/NotetakerShell.swift
@@ -138,7 +138,10 @@ struct NotetakerShell: View {
 
         guard !HotkeyCapture.shared.isCapturing else { return }
 
-        if settings.hotkey != settings.pushToTalkHotkey {
+        // Dois bindings na mesma tecla fn brigam pelo mesmo evento: o toque que
+        // começa o "segura pra falar" seria o mesmo que fecha o duplo toque.
+        let shareFunctionKey = settings.hotkey.isFunctionKey && settings.pushToTalkHotkey.isFunctionKey
+        if settings.hotkey != settings.pushToTalkHotkey, !shareFunctionKey {
             toggleHotkey.register(
                 settings.hotkey,
                 onPress: { toggleDictation() },
@@ -153,12 +156,18 @@ struct NotetakerShell: View {
     }
 
     private func pushToTalkPressed() {
-        guard !model.phase.isRunning, !dictation.isRunning else { return }
+        guard !model.phase.isRunning else { return }
+        // Duplo toque não tem "solta": vira liga/desliga, como o outro atalho.
+        guard !settings.pushToTalkHotkey.isDoubleTap else {
+            toggleDictation()
+            return
+        }
+        guard !dictation.isRunning else { return }
         startDictation()
     }
 
     private func pushToTalkReleased() {
-        guard dictation.isRunning else { return }
+        guard dictation.isRunning, !settings.pushToTalkHotkey.isDoubleTap else { return }
         finishDictation()
     }
 
@@ -171,7 +180,10 @@ struct NotetakerShell: View {
         dictation.start(
             localeIdentifier: settings.localeIdentifier,
             mode: settings.recognitionMode,
+            inputDeviceUID: settings.inputDeviceUID,
+            contextualTerms: SpokenTerms.all(with: snippets.snippets.map(\.expansion)),
             formatAsMarkdown: settings.formatAsMarkdown,
+            polishTerms: settings.polishTerms,
             expand: { snippets.expand($0) }
         )
         island.isSessionActive = true
@@ -200,6 +212,7 @@ struct NotetakerShell: View {
         } else {
             model.localeIdentifier = settings.localeIdentifier
             model.recognitionMode = settings.recognitionMode
+            model.inputDeviceUID = settings.inputDeviceUID
             if settings.captureSystemAudio {
                 model.startCall()
             } else {

--- a/Sources/SpeechMD/Settings/AppSettings.swift
+++ b/Sources/SpeechMD/Settings/AppSettings.swift
@@ -28,6 +28,11 @@ final class AppSettings {
         }
     }
 
+    /// UID do microfone escolhido; vazio significa o padrão do sistema.
+    var inputDeviceUID: String {
+        didSet { defaults.set(inputDeviceUID, forKey: Keys.inputDeviceUID) }
+    }
+
     var recognitionMode: RecognitionMode {
         didSet { defaults.set(recognitionMode.rawValue, forKey: Keys.recognitionMode) }
     }
@@ -42,6 +47,10 @@ final class AppSettings {
 
     var formatAsMarkdown: Bool {
         didSet { defaults.set(formatAsMarkdown, forKey: Keys.formatAsMarkdown) }
+    }
+
+    var polishTerms: Bool {
+        didSet { defaults.set(polishTerms, forKey: Keys.polishTerms) }
     }
 
     var soundFeedback: Bool {
@@ -60,11 +69,13 @@ final class AppSettings {
         localeIdentifier = defaults.string(forKey: Keys.locale) ?? "pt-BR"
         appearance = defaults.string(forKey: Keys.appearance)
             .flatMap(AppAppearance.init(rawValue:)) ?? .system
+        inputDeviceUID = defaults.string(forKey: Keys.inputDeviceUID) ?? ""
         recognitionMode = defaults.string(forKey: Keys.recognitionMode)
             .flatMap(RecognitionMode.init(rawValue:)) ?? .lowLatency
         captureSystemAudio = defaults.object(forKey: Keys.captureSystemAudio) as? Bool ?? true
         showIsland = defaults.object(forKey: Keys.showIsland) as? Bool ?? true
         formatAsMarkdown = defaults.object(forKey: Keys.formatAsMarkdown) as? Bool ?? false
+        polishTerms = defaults.object(forKey: Keys.polishTerms) as? Bool ?? false
         soundFeedback = defaults.object(forKey: Keys.soundFeedback) as? Bool ?? true
         hapticFeedback = defaults.object(forKey: Keys.hapticFeedback) as? Bool ?? true
         Language.isEnglish = Language.matches(localeIdentifier: localeIdentifier)
@@ -86,10 +97,12 @@ final class AppSettings {
         static let pushToTalkHotkey = "pushToTalkHotkey"
         static let locale = "localeIdentifier"
         static let appearance = "appearance"
+        static let inputDeviceUID = "inputDeviceUID"
         static let recognitionMode = "recognitionMode"
         static let captureSystemAudio = "captureSystemAudio"
         static let showIsland = "showIsland"
         static let formatAsMarkdown = "formatAsMarkdown"
+        static let polishTerms = "polishTerms"
         static let soundFeedback = "soundFeedback"
         static let hapticFeedback = "hapticFeedback"
     }

--- a/Sources/SpeechMD/Settings/Feedback.swift
+++ b/Sources/SpeechMD/Settings/Feedback.swift
@@ -26,9 +26,14 @@ enum Feedback {
         }
     }
 
+    /// Os sons do sistema tocam em volume cheio, e o do ditado dispara com a
+    /// janela escondida, colado no ouvido de quem está de headset.
+    private static let volume: Float = 0.25
+
     static func play(_ kind: Kind, sound: Bool, haptic: Bool) {
-        if sound {
-            NSSound(named: kind.soundName)?.play()
+        if sound, let effect = NSSound(named: kind.soundName) {
+            effect.volume = volume
+            effect.play()
         }
         if haptic {
             NSHapticFeedbackManager.defaultPerformer.perform(

--- a/Sources/SpeechMD/Settings/GlobalHotkey.swift
+++ b/Sources/SpeechMD/Settings/GlobalHotkey.swift
@@ -16,6 +16,7 @@ final class GlobalHotkey {
     private var eventHandler: EventHandlerRef?
     private var flagsMonitors: [Any] = []
     private var isFunctionKeyDown = false
+    private var lastFunctionTapAt: Date?
     private var onPress: (() -> Void)?
     private var onRelease: (() -> Void)?
 
@@ -32,7 +33,7 @@ final class GlobalHotkey {
         self.onRelease = onRelease
 
         guard !binding.isFunctionKey else {
-            observeFunctionKey()
+            observeFunctionKey(doubleTap: binding.isDoubleTap)
             return
         }
 
@@ -56,15 +57,32 @@ final class GlobalHotkey {
         flagsMonitors.forEach(NSEvent.removeMonitor)
         flagsMonitors = []
         isFunctionKeyDown = false
+        lastFunctionTapAt = nil
     }
 
-    private func observeFunctionKey() {
+    /// No duplo toque não existe "segurar": o segundo toque dispara e pronto,
+    /// então quem usa esse binding trata como liga/desliga.
+    private func observeFunctionKey(doubleTap: Bool) {
         let handle: (NSEvent) -> Void = { [weak self] event in
             guard let self, event.keyCode == HotkeyBinding.fnKeyCode else { return }
             let isDown = event.modifierFlags.contains(.function)
             guard isDown != isFunctionKeyDown else { return }
             isFunctionKeyDown = isDown
-            isDown ? onPress?() : onRelease?()
+
+            guard doubleTap else {
+                isDown ? onPress?() : onRelease?()
+                return
+            }
+            guard isDown else { return }
+
+            let now = Date()
+            if let last = lastFunctionTapAt,
+               now.timeIntervalSince(last) <= HotkeyBinding.doubleTapWindow {
+                lastFunctionTapAt = nil
+                onPress?()
+            } else {
+                lastFunctionTapAt = now
+            }
         }
 
         if let global = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, handler: handle) {

--- a/Sources/SpeechMD/Settings/HotkeyBinding.swift
+++ b/Sources/SpeechMD/Settings/HotkeyBinding.swift
@@ -5,6 +5,8 @@ import Carbon.HIToolbox
 struct HotkeyBinding: Equatable, Codable {
     var keyCode: UInt32
     var modifiers: UInt
+    /// Opcional para não invalidar os atalhos já salvos em UserDefaults.
+    var doubleTap: Bool?
 
     /// ⌥⌘R. Space com ⌘ é da busca do sistema e nunca chegaria ao app.
     static let `default` = HotkeyBinding(keyCode: 15, modifiers: NSEvent.ModifierFlags([.option, .command]).rawValue)
@@ -13,7 +15,15 @@ struct HotkeyBinding: Equatable, Codable {
 
     static let fn = HotkeyBinding(keyCode: fnKeyCode, modifiers: 0)
 
+    /// Dois toques em fn, como o ditado do próprio macOS.
+    static let fnDouble = HotkeyBinding(keyCode: fnKeyCode, modifiers: 0, doubleTap: true)
+
     var isFunctionKey: Bool { keyCode == Self.fnKeyCode }
+
+    var isDoubleTap: Bool { doubleTap == true }
+
+    /// Janela entre os dois toques, no gravador e no atalho global.
+    static let doubleTapWindow: TimeInterval = 0.4
 
     var modifierFlags: NSEvent.ModifierFlags {
         NSEvent.ModifierFlags(rawValue: modifiers)
@@ -21,7 +31,7 @@ struct HotkeyBinding: Equatable, Codable {
 
     /// "⌥⌘Space" — ordem igual à dos menus do sistema.
     var displayString: String {
-        if isFunctionKey { return "fn" }
+        if isFunctionKey { return isDoubleTap ? "fn fn" : "fn" }
         var result = ""
         if modifierFlags.contains(.control) { result += "⌃" }
         if modifierFlags.contains(.option) { result += "⌥" }

--- a/Sources/SpeechMD/Settings/SettingsView.swift
+++ b/Sources/SpeechMD/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ struct SettingsView: View {
     @Bindable var settings: AppSettings
 
     @State private var permissionsRefreshedAt = Date()
+    @State private var inputDevices = AudioInputDevice.available
 
 
     var body: some View {
@@ -35,7 +36,7 @@ struct SettingsView: View {
 
                     SettingsRow(
                         title: t("Iniciar e parar gravação", "Start and stop recording"),
-                        subtitle: t("Um toque começa, o toque seguinte encerra e cola o texto.", "One tap starts, the next stops and pastes the text.")
+                        subtitle: t("Um toque começa, o toque seguinte encerra e cola o texto. Para gravar \"fn fn\", toque fn duas vezes seguidas.", "One tap starts, the next stops and pastes the text. To record \"fn fn\", tap fn twice in a row.")
                     ) {
                         ShortcutRecorderView(binding: $settings.hotkey)
                     }
@@ -73,6 +74,22 @@ struct SettingsView: View {
                     Divider().overlay(Theme.border)
 
                     SettingsRow(
+                        title: t("Microfone", "Microphone"),
+                        subtitle: t("Vale para o ditado e para a sua trilha nas reuniões. Se o aparelho escolhido estiver desconectado, o padrão do sistema assume.", "Applies to dictation and to your track in meetings. If the chosen device is disconnected, the system default takes over.")
+                    ) {
+                        Picker("", selection: $settings.inputDeviceUID) {
+                            Text(t("Padrão do sistema", "System default")).tag("")
+                            ForEach(inputDevices) { device in
+                                Text(device.name).tag(device.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    Divider().overlay(Theme.border)
+
+                    SettingsRow(
                         title: t("Modo", "Mode"),
                         subtitle: t("Latência menor ou transcrição mais precisa.", "Lower latency or more accurate transcription.")
                     ) {
@@ -97,6 +114,20 @@ struct SettingsView: View {
                             .labelsHidden()
                             .toggleStyle(.switch)
                             .disabled(!TranscriptFormatter.isAvailable)
+                    }
+
+                    Divider().overlay(Theme.border)
+
+                    SettingsRow(
+                        title: t("Corrigir termos estrangeiros", "Fix foreign terms"),
+                        subtitle: TermPolisher.isAvailable
+                            ? t("Segunda passada pelo modelo para palavras que o dicionário não reconhece. O vocabulário técnico já vai como pista para o reconhecedor de graça, então ligue isto só se ainda escapar termo errado: custa cerca de 1s antes de colar.", "A second pass through the model for words the dictionary doesn't know. The technical vocabulary already goes to the recognizer as a hint for free, so turn this on only if terms still come out wrong: it costs about 1s before pasting.")
+                            : t("Indisponível: requer Apple Intelligence ativa neste Mac.", "Unavailable: requires Apple Intelligence enabled on this Mac.")
+                    ) {
+                        Toggle("", isOn: $settings.polishTerms)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .disabled(!TermPolisher.isAvailable)
                     }
                 }
 
@@ -158,6 +189,7 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             permissionsRefreshedAt = Date()
+            inputDevices = AudioInputDevice.available
         }
     }
 }

--- a/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
+++ b/Sources/SpeechMD/Settings/ShortcutRecorderView.swift
@@ -61,8 +61,16 @@ final class KeyCaptureNSView: NSView {
     var onCapture: ((HotkeyBinding) -> Void)?
 
     private var isRecording = false {
-        didSet { onRecordingChange?(isRecording) }
+        didSet {
+            if !isRecording {
+                singleTapTask?.cancel()
+                singleTapTask = nil
+            }
+            onRecordingChange?(isRecording)
+        }
     }
+
+    private var singleTapTask: Task<Void, Never>?
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -76,13 +84,32 @@ final class KeyCaptureNSView: NSView {
         return true
     }
 
+    /// fn não é gravado no primeiro toque: sem esperar a janela do duplo toque
+    /// não dá para distinguir "fn" de "fn fn".
     override func flagsChanged(with event: NSEvent) {
         guard isRecording, event.keyCode == HotkeyBinding.fnKeyCode else {
             super.flagsChanged(with: event)
             return
         }
         guard event.modifierFlags.contains(.function) else { return }
-        onCapture?(.fn)
+
+        if singleTapTask != nil {
+            singleTapTask?.cancel()
+            singleTapTask = nil
+            capture(.fnDouble)
+            return
+        }
+
+        singleTapTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(HotkeyBinding.doubleTapWindow))
+            guard !Task.isCancelled, let self else { return }
+            singleTapTask = nil
+            capture(.fn)
+        }
+    }
+
+    private func capture(_ binding: HotkeyBinding) {
+        onCapture?(binding)
         isRecording = false
     }
 
@@ -104,8 +131,7 @@ final class KeyCaptureNSView: NSView {
         )
         guard candidate.isValid else { return }
 
-        onCapture?(candidate)
-        isRecording = false
+        capture(candidate)
     }
 
     /// Combinação com ⌘ vira key equivalent e seria consumida pelo menu antes

--- a/Sources/SpeechMD/Snippets/SnippetStore.swift
+++ b/Sources/SpeechMD/Snippets/SnippetStore.swift
@@ -64,6 +64,12 @@ final class SnippetStore {
                       options: [.caseInsensitive, .diacriticInsensitive],
                       range: searchStart..<result.endIndex
                   ) {
+                // "conte" não pode casar dentro de "acontece": o gatilho tem
+                // que ser a palavra inteira, não um pedaço dela.
+                guard Self.isWholeWord(range, in: result) else {
+                    searchStart = result.index(after: range.lowerBound)
+                    continue
+                }
                 result.replaceSubrange(range, with: snippet.expansion)
                 guard let next = result.index(
                     range.lowerBound,
@@ -74,6 +80,19 @@ final class SnippetStore {
             }
         }
         return result
+    }
+
+    static func isWholeWord(_ range: Range<String.Index>, in text: String) -> Bool {
+        let before = range.lowerBound > text.startIndex
+            ? text[text.index(before: range.lowerBound)]
+            : nil
+        let after = range.upperBound < text.endIndex ? text[range.upperBound] : nil
+        return !isWordCharacter(before) && !isWordCharacter(after)
+    }
+
+    private static func isWordCharacter(_ character: Character?) -> Bool {
+        guard let character else { return false }
+        return character.isLetter || character.isNumber
     }
 
     private func persist() {

--- a/Sources/SpeechMD/Speech/AudioInputDevice.swift
+++ b/Sources/SpeechMD/Speech/AudioInputDevice.swift
@@ -1,0 +1,47 @@
+import AVFoundation
+import CoreAudio
+import Foundation
+
+/// Um microfone disponível no sistema.
+///
+/// O identificador guardado é o UID do dispositivo, não o `AudioDeviceID`: o
+/// número muda a cada reconexão ou reboot, o UID não.
+struct AudioInputDevice: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+
+    static var available: [AudioInputDevice] {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.microphone, .external],
+            mediaType: .audio,
+            position: .unspecified
+        )
+        .devices
+        .map { AudioInputDevice(id: $0.uniqueID, name: $0.localizedName) }
+    }
+
+    /// Traduz o UID para o identificador que o AudioUnit entende.
+    static func coreAudioID(for uid: String) -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslateUIDToDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var cfUID = uid as CFString
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+
+        let status = withUnsafeMutablePointer(to: &cfUID) { uidPointer in
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                UInt32(MemoryLayout<CFString>.size),
+                uidPointer,
+                &size,
+                &deviceID
+            )
+        }
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+}

--- a/Sources/SpeechMD/Speech/SpeechPipeline.swift
+++ b/Sources/SpeechMD/Speech/SpeechPipeline.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import AudioToolbox
 import CoreMedia
 import Foundation
 import Speech
@@ -68,6 +69,8 @@ actor SpeechPipeline {
 
     private let requestedLocale: Locale
     private let mode: RecognitionMode
+    private let inputDeviceUID: String?
+    private let contextualTerms: [String]
     private var analyzer: SpeechAnalyzer?
     private var resultTask: Task<Void, Never>?
     private var audioEngine: AVAudioEngine?
@@ -78,9 +81,42 @@ actor SpeechPipeline {
     private var volatileSegment = ""
     private var resetClockOnNextAudio = false
 
-    init(localeIdentifier: String, mode: RecognitionMode) {
+    init(
+        localeIdentifier: String,
+        mode: RecognitionMode,
+        inputDeviceUID: String? = nil,
+        contextualTerms: [String] = SpokenTerms.all()
+    ) {
         requestedLocale = Locale(identifier: localeIdentifier)
         self.mode = mode
+        self.inputDeviceUID = inputDeviceUID
+        self.contextualTerms = contextualTerms
+    }
+
+    /// Pista de vocabulário para o reconhecedor: os estrangeirismos saem
+    /// escritos certo já na transcrição, sem custar nada depois.
+    private func analysisContext() -> AnalysisContext {
+        let context = AnalysisContext()
+        context.contextualStrings = [.general: contextualTerms]
+        return context
+    }
+
+    /// Aponta o engine para o microfone escolhido nos ajustes. Sem escolha, ou
+    /// com o dispositivo desconectado, fica o padrão do sistema.
+    private func selectInputDevice(on input: AVAudioInputNode) {
+        guard let inputDeviceUID,
+              let audioUnit = input.audioUnit,
+              var deviceID = AudioInputDevice.coreAudioID(for: inputDeviceUID)
+        else { return }
+
+        AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
     }
 
     func startMicrophone(onEvent: @escaping EventHandler) async throws {
@@ -92,6 +128,9 @@ actor SpeechPipeline {
 
         let engine = AVAudioEngine()
         let input = engine.inputNode
+        // Antes de ler o formato: trocar o dispositivo depois disso deixaria o
+        // tap com a taxa de amostragem do microfone antigo.
+        selectInputDevice(on: input)
         let inputFormat = input.outputFormat(forBus: 0)
         guard inputFormat.channelCount > 0 else {
             throw SpeechPipelineError.noMicrophone
@@ -227,6 +266,7 @@ actor SpeechPipeline {
             )
             try await ensureAssets(for: [transcriber])
             let analyzer = SpeechAnalyzer(modules: [transcriber], options: options)
+            try await analyzer.setContext(analysisContext())
             return .dictation(analyzer, transcriber)
 
         case .quality:
@@ -244,6 +284,7 @@ actor SpeechPipeline {
             )
             try await ensureAssets(for: [transcriber])
             let analyzer = SpeechAnalyzer(modules: [transcriber], options: options)
+            try await analyzer.setContext(analysisContext())
             return .speech(analyzer, transcriber)
         }
     }

--- a/Sources/SpeechMD/Speech/SpokenTerms.swift
+++ b/Sources/SpeechMD/Speech/SpokenTerms.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Termos que o reconhecedor recebe como pista antes de ouvir.
+///
+/// É o caminho barato para os estrangeirismos: o `SpeechAnalyzer` enviesa o
+/// reconhecimento com essa lista durante a própria transcrição, então "function"
+/// sai certo sem nenhuma passada de correção depois — custo zero de latência.
+enum SpokenTerms {
+    /// Vocabulário de quem fala de trabalho e de código misturando inglês.
+    static let technical = [
+        "briefing", "deadline", "feedback", "meeting", "call", "budget",
+        "insight", "kickoff", "follow-up", "onboarding", "review", "sprint",
+        "backlog", "roadmap", "milestone", "stakeholder", "board",
+        "function", "class", "array", "string", "boolean", "cache", "commit",
+        "merge", "branch", "pull request", "deploy", "build", "release",
+        "bug", "feature", "refactor", "endpoint", "payload", "token",
+        "framework", "library", "package", "runtime", "backend", "frontend",
+        "design", "layout", "dashboard", "landing page", "template",
+        "workspace", "pipeline", "workflow", "dropdown", "checkbox", "toggle"
+    ]
+
+    /// A lista final: os termos fixos mais o que a pessoa cadastrou no
+    /// dicionário de voz, que é onde moram os nomes próprios dela.
+    static func all(with custom: [String] = []) -> [String] {
+        let extra = custom
+            .flatMap { $0.split(separator: " ").map(String.init) }
+            .filter { $0.count >= 3 }
+        return Array(Set(technical + extra))
+    }
+}


### PR DESCRIPTION
## O que muda

**Termos estrangeiros sem custo de latência**
O `SpeechAnalyzer` recebe o vocabulário antes de ouvir, via `AnalysisContext.contextualStrings`: ~55 termos de trabalho e código (`SpokenTerms`) mais as expansões do dicionário de voz. "function" sai escrito certo durante a transcrição, sem passada nenhuma depois.

Uma segunda passada pelo modelo on-device (`TermPolisher`) continua disponível para o que escapar, mas **desligada por padrão**: ela custa cerca de 1s antes de colar. Só as palavras que o `NSSpellChecker` não reconhece vão ao modelo, uma por linha, com cache e `prewarm`; a frase nunca é reescrita.

**Microfone**
Picker nos ajustes, valendo para o ditado e para a sua trilha nas reuniões. Guarda o UID do dispositivo (o `AudioDeviceID` muda a cada reconexão) e aponta o `AVAudioEngine` antes de ler o formato do input. Dispositivo desconectado cai no padrão do sistema.

**fn fn**
O gravador de atalho espera 400ms antes de salvar o fn, que é o que permite distinguir `fn` de `fn fn`. No duplo toque não existe "segurar", então ele age como liga/desliga mesmo no campo de push to talk. Dois bindings na mesma tecla fn brigam pelo mesmo evento: nesse caso só o push to talk é registrado.

**Correções**
- Gatilho do dicionário só expande como palavra inteira: "conte" virava "Conty" dentro de "acontece".
- O som de retorno tocava em volume cheio do sistema, agora vai em 0.25.

## Teste

Build verde. O vocabulário e a expansão foram verificados com casos reais ("acontece", "acontecendo", "desconte", "conte comigo", maiúscula, múltiplas ocorrências). A latência da passada opcional foi medida no modelo real: 0.28s para 1 palavra, 0.98s para 2, 0s quando não há palavra desconhecida.