### PR TITLE
Retry the fn tap once Accessibility is granted

### DIFF
--- a/Sources/SpeechMD/Settings/FunctionKeyTap.swift
+++ b/Sources/SpeechMD/Settings/FunctionKeyTap.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 @preconcurrency import CoreGraphics
 
 /// Intercepta a tecla fn antes do sistema e engole o toque solto.
@@ -15,8 +16,13 @@ final class FunctionKeyTap {
     /// `isDown` do fn. Chamado antes de o evento seguir (ou ser engolido).
     var onChange: ((Bool) -> Void)?
 
+    /// De quanto em quanto tempo se reconfere a Acessibilidade enquanto o tap
+    /// não pôde nascer.
+    private static let authorizationPollInterval = Duration.seconds(1)
+
     private var tap: CFMachPort?
     private var source: CFRunLoopSource?
+    private var authorizationTask: Task<Void, Never>?
     private var isFunctionKeyDown = false
     private var usedWithOtherKey = false
 
@@ -24,7 +30,35 @@ final class FunctionKeyTap {
 
     func start() {
         guard tap == nil else { return }
+        guard install() else {
+            // `tapCreate` só devolve um tap com a Acessibilidade concedida, e a
+            // permissão chega com o app já aberto: o painel de Ajustes é aberto
+            // depois do launch. Desistir aqui deixa o fn morto até um relaunch,
+            // que é o que acontecia com todo mundo na primeira execução.
+            awaitAuthorization()
+            return
+        }
+    }
 
+    func stop() {
+        authorizationTask?.cancel()
+        authorizationTask = nil
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+        }
+        if let source {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        tap = nil
+        source = nil
+        isFunctionKeyDown = false
+        usedWithOtherKey = false
+    }
+
+    /// Cria e liga o tap. `false` quando o sistema recusa — na prática, quando a
+    /// Acessibilidade ainda não foi concedida.
+    private func install() -> Bool {
         let mask = (1 << CGEventType.flagsChanged.rawValue)
             | (1 << CGEventType.keyDown.rawValue)
 
@@ -41,26 +75,31 @@ final class FunctionKeyTap {
                 }
             },
             userInfo: Unmanaged.passUnretained(self).toOpaque()
-        ) else { return }
+        ) else { return false }
 
         self.tap = tap
         source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        return true
     }
 
-    func stop() {
-        if let tap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            CFMachPortInvalidate(tap)
+    /// Espera a Acessibilidade chegar e liga o tap sozinho. Uma sondagem a cada
+    /// segundo é mais barata que a alternativa: `com.apple.accessibility.api`
+    /// não é documentada e chega antes de `AXIsProcessTrusted` virar `true`.
+    private func awaitAuthorization() {
+        guard authorizationTask == nil else { return }
+
+        authorizationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.authorizationPollInterval)
+                guard let self, !Task.isCancelled else { return }
+                guard tap == nil else { return }
+                guard AXIsProcessTrusted(), install() else { continue }
+                break
+            }
+            self?.authorizationTask = nil
         }
-        if let source {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-        }
-        tap = nil
-        source = nil
-        isFunctionKeyDown = false
-        usedWithOtherKey = false
     }
 
     private func handle(


### PR DESCRIPTION
Fixes #9.

`CGEvent.tapCreate` only returns a tap when Accessibility is already granted, and the permission arrives with the app running — the Settings pane opens after launch. `start()` returned silently on that nil and `observeFunctionKey()` calls it once, so the tap was never created again and fn stayed dead until a relaunch.

That is the path every first run takes, and nothing in the UI says so: the window works, **Falar** works, the permission banner clears, only fn does nothing.

## What changed

- Tap creation moves into `install()`, so `start()` can tell "created" from "refused".
- When it is refused, a task polls `AXIsProcessTrusted()` once a second and installs the tap as soon as the permission lands. `stop()` cancels it.

Polling rather than `com.apple.accessibility.api` on purpose: that notification name is undocumented and fires slightly before `AXIsProcessTrusted()` flips, so it would need a second timer anyway. At 1 Hz against a local TCC check the cost is nil, and it stops the moment the tap exists.

## Testing

Clean `swift build` on macOS 26.3.1 / Swift 6.2, Apple Silicon.

I could not run the full grant-while-running loop against a bundle I built: `bundle.sh` signs with `speech.md Local`, and TCC ties permissions to the signature, so a locally signed rebuild is a different app to the system and cannot inherit the cask build's grants. The logic is small enough to read, but a runtime pass on your side is worth it — `tccutil reset Accessibility dev.anderson.speech-md`, relaunch, grant while it runs, and fn should come alive within a second without a relaunch.

Also worth knowing: the same `#Preview` in `DynamicIslandView.swift` blocks `swift build` on a Command Line Tools install, since the `PreviewsMacros` plugin ships with Xcode. I stripped it locally to build and it is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
