### PR TITLE
Keep the transcript when a file's last read fails

### DIFF
--- a/Sources/SpeechMD/Speech/SpeechPipeline.swift
+++ b/Sources/SpeechMD/Speech/SpeechPipeline.swift
@@ -71,6 +71,11 @@ actor SpeechPipeline {
     private let mode: RecognitionMode
     private let inputDeviceUID: String?
     private let contextualTerms: [String]
+    /// Blocos de leitura de arquivo. Grande o bastante para o custo por bloco
+    /// sumir, pequeno o bastante para o analyzer começar enquanto o resto do
+    /// arquivo ainda está sendo lido.
+    private static let fileReadChunk: AVAudioFrameCount = 8192
+
     private var analyzer: SpeechAnalyzer?
     private var resultTask: Task<Void, Never>?
     private var audioEngine: AVAudioEngine?
@@ -208,18 +213,30 @@ actor SpeechPipeline {
         onEvent: @escaping EventHandler
     ) async throws -> BenchmarkResult {
         let file = try AVAudioFile(forReading: url)
-        let duration = Double(file.length) / file.processingFormat.sampleRate
+        let fileFormat = file.processingFormat
+        let duration = Double(file.length) / fileFormat.sampleRate
         let prepared = try await preparePipeline()
         let analyzer = prepared.analyzer
 
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: prepared.modules,
+            considering: fileFormat
+        ), let converter = AVAudioConverter(from: fileFormat, to: analyzerFormat) else {
+            throw SpeechPipelineError.unavailable
+        }
+
+        let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
+
         self.analyzer = analyzer
         startConsumingResults(from: prepared, onEvent: onEvent)
-        try await analyzer.prepareToAnalyze(in: file.processingFormat)
+        try await analyzer.prepareToAnalyze(in: analyzerFormat)
 
         let clock = ContinuousClock()
         let start = clock.now
         resetRunState(at: start)
-        try await analyzer.start(inputAudioFile: file, finishAfterFile: true)
+        try await analyzer.start(inputSequence: inputSequence)
+        await feed(file, through: converter, as: analyzerFormat, into: inputBuilder)
+        inputBuilder.finish()
         try await analyzer.finalizeAndFinishThroughEndOfInput()
         let elapsed = start.duration(to: clock.now).seconds
         await resultTask?.value
@@ -228,6 +245,67 @@ actor SpeechPipeline {
             audioDurationSeconds: duration,
             processingSeconds: elapsed
         )
+    }
+
+    /// Lê o arquivo em blocos e entrega ao analyzer, tratando erro de leitura
+    /// como fim do áudio em vez de deixá-lo derrubar a transcrição inteira.
+    ///
+    /// O Opus que o WhatsApp grava declara no último page um granule position
+    /// maior do que os pacotes contêm: `AVAudioFile.length` promete alguns
+    /// frames a mais do que o decodificador entrega, e o `read` final estoura.
+    /// `ExtAudioFile` tolera a mesma cauda — o arquivo toca em qualquer player —
+    /// e 40 ms tortos no fim não podem custar os 100 s já transcritos.
+    private func feed(
+        _ file: AVAudioFile,
+        through converter: AVAudioConverter,
+        as analyzerFormat: AVAudioFormat,
+        into continuation: AsyncStream<AnalyzerInput>.Continuation
+    ) async {
+        let sourceFormat = file.processingFormat
+        let ratio = analyzerFormat.sampleRate / sourceFormat.sampleRate
+
+        while file.framePosition < file.length {
+            guard let source = AVAudioPCMBuffer(
+                pcmFormat: sourceFormat,
+                frameCapacity: Self.fileReadChunk
+            ) else { return }
+
+            do {
+                try file.read(into: source)
+            } catch {
+                return
+            }
+            guard source.frameLength > 0 else { return }
+
+            let capacity = AVAudioFrameCount(ceil(Double(source.frameLength) * ratio)) + 1
+            guard let converted = AVAudioPCMBuffer(
+                pcmFormat: analyzerFormat,
+                frameCapacity: capacity
+            ) else { return }
+
+            let input = ConverterInput(source)
+            var conversionError: NSError?
+            let status = converter.convert(to: converted, error: &conversionError) { _, outputStatus in
+                if input.wasSupplied {
+                    outputStatus.pointee = .noDataNow
+                    return nil
+                }
+                input.wasSupplied = true
+                outputStatus.pointee = .haveData
+                return input.buffer
+            }
+
+            // `.inputRanDry` é o caminho normal aqui: a capacidade de saída tem
+            // uma folga de um frame, então o conversor nunca chega a enchê-la e
+            // nunca reporta `.haveData`. O que importa é ter saído áudio.
+            guard conversionError == nil,
+                  status == .haveData || status == .inputRanDry,
+                  converted.frameLength > 0
+            else { return }
+
+            continuation.yield(AnalyzerInput(buffer: converted))
+            await Task.yield()
+        }
     }
 
     func stop() async {


### PR DESCRIPTION
Fixes #10.

WhatsApp writes a granule position on the final Ogg page larger than the packets decode to, so `AVAudioFile.length` promises a few frames more than the decoder delivers and the last `read` throws. `ExtAudioFile` tolerates the same tail — `afconvert` decodes the file whole and every player plays it — so nothing about the audio looks wrong.

`start(inputAudioFile:finishAfterFile:)` propagates that throw, `finalizeAndFinishThroughEndOfInput()` fails, and the run is discarded. On a 102.63s voice message the decoder stops at frame 4924488 of 4926408: **40 ms of bad tail threw away 102.59s of transcript that was already recognised.**

## What changed

`benchmarkFile` now reads the file in 8192-frame chunks and feeds the analyzer through `inputSequence`, with a read error treated as end of audio rather than an abort.

The file path gets its own converter instead of going through `AudioInputBridge`. That one yields only on `.haveData`, and a resampling converter never reports it here: the output capacity carries a spare frame, so it is never filled and `.inputRanDry` comes back instead — with valid frames in it. A standalone probe at 48kHz→16kHz returns `.inputRanDry` on every call, including with the microphone's own format:

```
call 0: st == .haveData? false | st == .inputRanDry? true | out.frameLength=80
call 1: st == .haveData? false | st == .inputRanDry? true | out.frameLength=85
call 2: st == .haveData? false | st == .inputRanDry? true | out.frameLength=85
```

I left `AudioInputBridge` alone rather than relax its guard, because I could not verify what the live path does at runtime without re-signing the bundle, and I would rather not touch a path that works for you on a guess. If it turns out the same applies there, the guard is worth a second look — it would be dropping every buffer that needs resampling.

## Testing

Four WhatsApp voice messages, pt-BR, lowLatency, macOS 26.3.1 / Apple Silicon, driving the same API sequence as `benchmarkFile`:

| file | before | after |
| --- | --- | --- |
| 76.31s | 4 finals, 202 words | 4 finals, 202 words |
| 79.97s | 7 finals, 175 words | 7 finals, 175 words |
| 108.43s | 5 finals, 247 words | 5 finals, 247 words |
| **102.63s** | **`nilError`, run lost** | **318 words, 1920 frames dropped** |

Throughput is unchanged at ~26-30x realtime on this machine, so the chunked feed does not cost anything measurable against `start(inputAudioFile:)`.

Note that `#Preview` in `DynamicIslandView.swift` blocks `swift build` on a Command Line Tools install, since `PreviewsMacros` ships with Xcode. I stripped it locally to build; it is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
